### PR TITLE
Use stricter ruby versioning to prevent future conflicts

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.rubygems_version      = "1.8.0"
-  s.required_ruby_version = ">= 1.9.3"
+  s.required_ruby_version = "~> 1.9.3"
 
   s.name                  = "github-pages"
   s.version               = "1"


### PR DESCRIPTION
`>= 1.9.3` => `~> 1.9.3`
