### PR TITLE
Use the GitHub URL as the Gem homepage

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.description           = "Bootstrap the GitHub Pages Jekyll environment locally."
   s.authors               = "GitHub, Inc."
   s.email                 = "support@github.com"
-  s.homepage              = "http://pages.github.com"
+  s.homepage              = "https://github.com/github/pages-gem"
   s.license               = "MIT"
 
   # Note to future Hubbers: Update the help docs if you bump the dependency versions


### PR DESCRIPTION
Rather than link out to http://pages.github.com from Rubygems.org,
point the gem homepage at the Gem repo to encourage developers
to contribute to the project.

Chances are, they probably already know what Pages is if they're
look at the Gem. If not, well, they should.
