### PR TITLE
Allow Ruby 1.9.3 & Up

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.rubygems_version      = "1.8.0"
-  s.required_ruby_version = "~> 1.9.3"
+  s.required_ruby_version = ">= 1.9.3"
 
   s.name                  = "github-pages"
   s.version               = "1"


### PR DESCRIPTION
I use Ruby 2.0.0-p247 for my Jekyll sites. It should not be an issue to use 1.9.3 and upward?
