### PR TITLE
Warn when not using Ruby 1.9

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.email                 = "support@github.com"
   s.homepage              = "https://github.com/github/pages-gem"
   s.license               = "MIT"
+  s.files                 = ["lib/github-pages.rb"]
 
   # Note to future Hubbers: Update the help docs if you bump the dependency versions
   # https://help.github.com/articles/using-jekyll-with-pages

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -1,0 +1,17 @@
+module PagesGem
+  PRODUCTION_RUBY = '~> 1.9'
+
+  require 'RedCloth'
+  require 'jekyll'
+  require 'kramdown'
+  require 'liquid'
+  require 'maruku'
+  require 'rdiscount'
+  require 'redcarpet'
+
+  unless Gem::Requirement.new(PRODUCTION_RUBY.dup).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+    puts "WARN: You are using Ruby 2.0, which is not officially " +
+         "supported by GitHub pages. You should switch to Ruby 1.9 " +
+         "to most closely match GitHub's production environment."
+  end
+end


### PR DESCRIPTION
Fixes #6

:construction: 

This will only warn if requiring the gem as a library. Maybe we'd need to update the usage instructions, but running `jekyll` directly will never raise this error. Alternatively we could package a CLI wrapper for this gem:

```
$ pages server
```

Which would just load everything and delegate to Jekyll. Thoughts?

/cc @benbalter @metaskills
