### PR TITLE
Rollback to liquid 2.5.1 for Jekyll 1.1.2 compatability

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency("RedCloth",   "= 4.2.9")
   s.add_dependency("jekyll",     "= 1.1.2")
   s.add_dependency("kramdown",   "= 1.0.2")
-  s.add_dependency("liquid",     "= 2.5.2")
+  s.add_dependency("liquid",     "= 2.5.1")
   s.add_dependency("maruku",     "= 0.6.1")
   s.add_dependency("rdiscount",  "= 1.6.8")
   s.add_dependency("redcarpet",  "= 2.2.2")


### PR DESCRIPTION
Fixes https://github.com/github/pages-gem/commit/f09dd3ef97bba2592275895ed070583bbddc9743#commitcomment-4077620

/cc @zerobase
