### PR TITLE
Update to jekyll v1.2.1

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.add_dependency("RedCloth",   "= 4.2.9")
   s.add_dependency("jekyll",     "= 1.2.1")
   s.add_dependency("kramdown",   "= 1.0.2")
-  s.add_dependency("liquid",     "= 2.5.1")
+  s.add_dependency("liquid",     "= 2.5.2")
   s.add_dependency("maruku",     "= 0.6.1")
   s.add_dependency("rdiscount",  "= 1.6.8")
-  s.add_dependency("redcarpet",  "= 2.2.2")
+  s.add_dependency("redcarpet",  "= 2.3.0")
 end


### PR DESCRIPTION
Jekyll v1.2.1 includes a very important bugfix for includes with Liquid 2.5.2. Upon update of Liquid to >= 2.5.2, this will be necessary. Does not affect Liquid 2.5.1.

Bumps version of RedCarpet to `~> 2.3.0` on Jekyll's end as well.

Close if this patch release isn't important to maintain the functionality of the current sites or if upgrading to Liquid 2.5.2 is undesirable.
