### PR TITLE
Bump to Jekyll v1.4.2

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency("jekyll",     "= 1.4.2")
   s.add_dependency("kramdown",   "= 1.2.0")
   s.add_dependency("liquid",     "= 2.5.4")
-  s.add_dependency("maruku",     "= 0.7.1")
+  s.add_dependency("maruku",     "= 0.7.0")
   s.add_dependency("rdiscount",  "= 2.1.7")
   s.add_dependency("redcarpet",  "= 2.3.0")
 


### PR DESCRIPTION
Only thing of Pages-specific importance is bumping of Maruku to 0.7.0.

[Full release post for v1.4.0](http://jekyllrb.com/news/2013/12/07/jekyll-1-4-0-released/), and the [full history](http://jekyllrb.com/docs/history/#140__20131207)

[Full release post for v1.4.1](http://jekyllrb.com/news/2013/12/10/jekyll-1-4-1-released/), and the [full history](http://jekyllrb.com/docs/history/#141__20131209)

[Full release post for v1.4.2](http://jekyllrb.com/news/2013/12/17/jekyll-1-4-2-released/), and the [full history](http://jekyllrb.com/docs/history/#142__20131217)
