### PR TITLE
Travis should use Ruby 2.0.0 to run CI check.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+rvm: 2.0.0
 script: "script/cibuild"
 
 notifications:


### PR DESCRIPTION
In an effort to best mimick running Jekyll on GitHub Pages infrastructure,
instruct TravisCI to use Ruby 2.0.0. While this isn't perfect (it's actually
running under GitHub's flavour of Ruby 2.0.0), it's better than running under
the Travis default of 1.9.3.
