### PR TITLE
Update Liquid to v2.5.5

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency("RedCloth",   "= 4.2.9")
   s.add_dependency("jekyll",     "= 1.4.2")
   s.add_dependency("kramdown",   "= 1.2.0")
-  s.add_dependency("liquid",     "= 2.5.4")
+  s.add_dependency("liquid",     "= 2.5.5")
   s.add_dependency("maruku",     "= 0.7.0")
   s.add_dependency("rdiscount",  "= 2.1.7")
   s.add_dependency("redcarpet",  "= 2.3.0")


### PR DESCRIPTION
Adds patch for security vulnerability detailed in https://github.com/Shopify/liquid/pull/299
