### PR TITLE
Expose GitHubPages::VERSION and GitHubPages.versions

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -1,4 +1,4 @@
-require './lib/version.rb'
+require './lib/github-pages.rb'
 
 Gem::Specification.new do |s|
   s.required_ruby_version = ">= 1.9.3"
@@ -11,18 +11,9 @@ Gem::Specification.new do |s|
   s.email                 = "support@github.com"
   s.homepage              = "https://github.com/github/pages-gem"
   s.license               = "MIT"
-  s.files                 = ["lib/github-pages.rb", "lib/version.rb"]
+  s.files                 = ["lib/github-pages.rb"]
 
-  # Jekyll and related dependency versions as used by GitHub Pages.
-  # For more information see:
-  # https://help.github.com/articles/using-jekyll-with-pages
-
-  s.add_dependency("RedCloth",   "= 4.2.9")
-  s.add_dependency("jekyll",     "= 1.4.2")
-  s.add_dependency("kramdown",   "= 1.2.0")
-  s.add_dependency("liquid",     "= 2.5.5")
-  s.add_dependency("maruku",     "= 0.7.0")
-  s.add_dependency("rdiscount",  "= 2.1.7")
-  s.add_dependency("redcarpet",  "= 2.3.0")
-
+  GitHubPages.gems.each do |gem, version|
+    s.add_dependency(gem, "= #{version}") unless gem == "github-pages"
+  end
 end

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -1,21 +1,19 @@
-require_relative "./version.rb"
-require 'RedCloth'
-require 'jekyll'
-require 'liquid'
-require 'maruku'
-require 'kramdown'
-require 'rdiscount'
-
 class GitHubPages
-  def self.versions
+  VERSION = 13
+
+  # Jekyll and related dependency versions as used by GitHub Pages.
+  # For more information see:
+  # https://help.github.com/articles/using-jekyll-with-pages
+  def self.gems
     {
-      "github-pages" => GitHubPages::VERSION.to_s,
-      "RedCloth" => RedCloth::VERSION.to_s,
-      "jekyll" => Jekyll::VERSION,
-      #"liquid" => Liquid::VERSION,
-      "maruku" => Maruku::VERSION,
-      "kramdown" => Kramdown::VERSION,
-      "RDiscount" => RDiscount::VERSION
+      "github-pages" => VERSION.to_s,
+      "jekyll"       => "1.4.2",
+      "kramdown"     => "1.2.0",
+      "liquid"       => "2.5.5",
+      "maruku"       => "0.7.0",
+      "rdiscount"    => "2.1.7",
+      "redcarpet"    => "2.3.0",
+      "RedCloth"     => "4.2.9"
     }
   end
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,0 @@
-class GitHubPages
-  VERSION = 13
-end


### PR DESCRIPTION
To allow programatic querying of GitHub Pages and dependency versions.
