### PR TITLE
Bump kramdown to 1.3.1

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -8,7 +8,7 @@ class GitHubPages
     {
       "github-pages" => VERSION.to_s,
       "jekyll"       => "1.4.2",
-      "kramdown"     => "1.2.0",
+      "kramdown"     => "1.3.1",
       "liquid"       => "2.5.5",
       "maruku"       => "0.7.0",
       "rdiscount"    => "2.1.7",


### PR DESCRIPTION
Fixes #37. Fixes #38.

This adapts #38 for the new way Gem versions are stored post https://github.com/github/pages-gem/pull/40.

//cc @CHH 
