### PR TITLE
Upgrade to Jekyll v1.4.3.

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -7,7 +7,7 @@ class GitHubPages
   def self.gems
     {
       "github-pages" => VERSION.to_s,
-      "jekyll"       => "1.4.2",
+      "jekyll"       => "1.4.3",
       "kramdown"     => "1.3.1",
       "liquid"       => "2.5.5",
       "maruku"       => "0.7.0",


### PR DESCRIPTION
This version bump patches 2 security vulnerabilities:
1. `Post#destination` allows path traversal due to the `CGI.unescape` called prior to the post URL being used in the generation of the output file path. URL escaped characters can be used in a permalink to bypass the filtering provided by `URL#sanitize_url`. (@gregose)
2. Arbitrary file reads via symlinks: it's possible to read anywhere on the filesystem by placing a symlink to a directory in `_includes`. (@charliesome)

Details: https://github.com/jekyll/jekyll/releases/tag/v1.4.3
