### PR TITLE
Expose ruby version via GitHubPages.versions

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.files                 = ["lib/github-pages.rb"]
 
   GitHubPages.gems.each do |gem, version|
-    s.add_dependency(gem, "= #{version}") unless gem == "github-pages"
+    s.add_dependency(gem, "= #{version}")
   end
 end

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -6,7 +6,6 @@ class GitHubPages
   # https://help.github.com/articles/using-jekyll-with-pages
   def self.gems
     {
-      "github-pages" => VERSION.to_s,
       "jekyll"       => "1.4.3",
       "kramdown"     => "1.3.1",
       "liquid"       => "2.5.5",
@@ -15,5 +14,14 @@ class GitHubPages
       "redcarpet"    => "2.3.0",
       "RedCloth"     => "4.2.9"
     }
+  end
+
+  # Versions used by GitHub Pages, including github-pages gem and ruby version
+  # Useful for programmatically querying for the current-running version
+  def self.versions
+    gems.merge({
+      "github-pages" => VERSION.to_s,
+      "ruby"         => RUBY_VERSION
+    })
   end
 end


### PR DESCRIPTION
Also moving `github-pages` into the new GitHubPages.versions hash for easier querying of dependencies.
