### PR TITLE
Bump Jekyll to 1.5.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -6,7 +6,7 @@ class GitHubPages
   # https://help.github.com/articles/using-jekyll-with-pages
   def self.gems
     {
-      "jekyll"               => "1.5.0",
+      "jekyll"               => "1.5.1",
       "kramdown"             => "1.3.1",
       "liquid"               => "2.5.5",
       "maruku"               => "0.7.0",


### PR DESCRIPTION
Updates `safe_yaml` and Windows FS problem. https://github.com/jekyll/jekyll/releases/tag/v1.5.0

Think it's worth locking `safe_yaml` to 1.0.something?
- [x] Update Jekyll to 1.5.0
- [x] Update jekyll-mentions
- [x] Update jemoji
