### PR TITLE
Add jekyll-sitemap to list of gem dependencies

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -16,6 +16,7 @@ class GitHubPages
       "jemoji"               => "0.1.0",
       "jekyll-mentions"      => "0.0.6",
       "jekyll-redirect-from" => "0.3.1",
+      "jekyll-sitemap"       => "0.2.0",
     }
   end
 


### PR DESCRIPTION
Let's allow users to easily generate sitemaps on GitHub Pages! Imagine how useful this is for documentation sites with pages for API's and miscellaneous usage materials! :smiley:
