### PR TITLE
Bump Jekyll to 2.0.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -6,7 +6,7 @@ class GitHubPages
   # https://help.github.com/articles/using-jekyll-with-pages
   def self.gems
     {
-      "jekyll"                => "2.0.2",
+      "jekyll"                => "2.0.3",
       "kramdown"              => "1.3.1",
       "liquid"                => "2.5.5",
       "maruku"                => "0.7.0",


### PR DESCRIPTION
It's out! :sparkling_heart: 
- [x] Bump Jekyll to 2.0.3 (https://github.com/jekyll/jekyll/compare/v1.5.1...v2.0.3)
- [x] Bump redcarpet to 3.1.1 (https://github.com/vmg/redcarpet/compare/v2.3.0...v3.1.1)
- [x] Bump jekyll-redirect-from to 0.4.0 (https://github.com/jekyll/jekyll-redirect-from/releases/tag/v0.4.0)
- [x] Bump jemoji to 0.2.0 (https://github.com/jekyll/jemoji/releases/tag/v0.2.0)
- [x] Bump jekyll-sitemap to 0.4.0 (https://github.com/jekyll/jekyll-sitemap/releases/tag/v0.4.0, https://github.com/jekyll/jekyll-sitemap/releases/tag/v0.3.0)
- [x] Bump jekyll-mentions to 0.1.0 (https://github.com/jekyll/jekyll-mentions/releases/tag/v0.1.0)
- [x] Add CoffeeScript converter dependency and lock to 1.0.0
- [x] Add Sass converter dependency and lock to 1.0.0

http://jekyllrb.com/news/2014/05/06/jekyll-turns-2-0-0/
