### PR TITLE
jsonball plugin added

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -17,6 +17,7 @@ class GitHubPages
       "jekyll-mentions"      => "0.0.6",
       "jekyll-redirect-from" => "0.3.1",
       "jekyll-sitemap"       => "0.2.0",
+      "jekyll-jsonball"      => "0.0.1",
     }
   end
 


### PR DESCRIPTION
Hey!
I noticed that the "whitelist" of Jekyll plugins misses a very simple but very useful candidate - jsonball (https://gist.github.com/ahgittin/1895282/).

The purpose of it is parsing JSON file in Jekyll variable, that can be further used to build the website based off JSON contents (without having to use JS and populate manually).
Since plugin was distributed as a simple gist, I followed the convention set by previous plugins: made a gem out of it, tested and added to the dependency list.

Hope you understand how nice would it be to have this plugin enabled on the live version and will accept this pull request ^_^

Have a great day!
Dmitrii.
