### PR TITLE
Update jekyll-sitemap to 0.3.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -16,7 +16,7 @@ class GitHubPages
       "jemoji"               => "0.1.0",
       "jekyll-mentions"      => "0.0.6",
       "jekyll-redirect-from" => "0.3.1",
-      "jekyll-sitemap"       => "0.2.0",
+      "jekyll-sitemap"       => "0.3.0",
     }
   end
 


### PR DESCRIPTION
Still compatible with Jekyll 1.5.1.

[Changes in jekyll-sitemap at 0.3.0](https://github.com/jekyll/jekyll-sitemap/releases/tag/v0.3.0):
- Generate sitemap using `html_pages` (https://github.com/jekyll/jekyll-sitemap/issues/10)
- Remove stray `sitemap.xsl` from template (https://github.com/jekyll/jekyll-sitemap/issues/8)
- Added Travis (https://github.com/jekyll/jekyll-sitemap/issues/6)
- Better timezone support in tests (https://github.com/jekyll/jekyll-sitemap/issues/7)
