### PR TITLE
Have users use bundler to install/update the gem and run jekyll

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Run the following command:
 
 ## Updating
 
-To update to the latest version of Jekyll and associated dependencies, simply run `bundle update github-pages`.
+To update to the latest version of Jekyll and associated dependencies, simply run `bundle update`.
 
 ## Project Goals
 


### PR DESCRIPTION
Have users use bundler to install/update the gem and run jekyll. This ensures that they don't run a pre-existing (potentially incorrect version of) jekyll by mistake. This is particularly important with Jekyll 2.0 being the latest release by GHP still using 1.5.1.
