### PR TITLE
Bump mentions to v0.0.9

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -14,7 +14,7 @@ class GitHubPages
       "redcarpet"            => "2.3.0",
       "RedCloth"             => "4.2.9",
       "jemoji"               => "0.1.0",
-      "jekyll-mentions"      => "0.0.8",
+      "jekyll-mentions"      => "0.0.9",
       "jekyll-redirect-from" => "0.3.1",
       "jekyll-sitemap"       => "0.3.0",
     }


### PR DESCRIPTION
Mentions should only happen on pages whose output extension is HTML. It caused `@media` queries to be output with HTML:

![screen shot 2014-06-23 at 5 32 15 pm](https://cloud.githubusercontent.com/assets/237985/3364319/dff0e0aa-fb1d-11e3-92a7-d299e5f0d171.png)

https://github.com/jekyll/jekyll-mentions/releases/tag/v0.0.7
