### PR TITLE
Upgrade to Jekyll 2.1

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -7,7 +7,7 @@ class GitHubPages
   def self.gems
     {
       # Jekyll
-      "jekyll"               => "2.1.1",
+      "jekyll"               => "2.2.0",
       "jekyll-coffeescript"  => "1.0.0",
       "jekyll-sass-converter" => "1.1.0",
 


### PR DESCRIPTION
- [x] Bump Jekyll to 2.1.1 (https://github.com/jekyll/jekyll/compare/v1.5.1...v2.1.1)
- [x] Bump Liquid to 2.6.1 (https://github.com/Shopify/liquid/compare/v2.5.4...v2.6.1)
- [x] Bump redcarpet to 3.1.1 (https://github.com/vmg/redcarpet/compare/v2.3.0...v3.1.1)
- [x] Bump jekyll-redirect-from to [v0.4.0](https://github.com/jekyll/jekyll-redirect-from/releases/tag/v0.4.0)
- [x] Bump jemoji to [v0.2.0](https://github.com/jekyll/jemoji/releases/tag/v0.2.0)
- [x] Bump jekyll-sitemap to 0.5.0 ([v0.5.0](https://github.com/jekyll/jekyll-sitemap/releases/tag/v0.5.0), [v0.4.1](https://github.com/jekyll/jekyll-sitemap/releases/tag/v0.4.1), [v0.4.1](https://github.com/jekyll/jekyll-sitemap/releases/tag/v0.4.0), [v0.3.0](https://github.com/jekyll/jekyll-sitemap/releases/tag/v0.3.0), https://github.com/jekyll/jekyll-sitemap/compare/v0.3.0...v0.4.1)
- [x] Bump jekyll-mentions to [v0.1.2](https://github.com/jekyll/jekyll-mentions/releases/tag/v0.1.2)
- [x] Add CoffeeScript converter dependency and lock to 1.0.0
- [x] Add Sass converter dependency and lock to 1.1.0

http://jekyllrb.com/news/2014/05/06/jekyll-turns-2-0-0/
http://jekyllrb.com/news/2014/06/28/jekyll-turns-21-i-mean-2-1-0/
