### PR TITLE
Bump jekyll-sitemap version

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -1,5 +1,5 @@
 class GitHubPages
-  VERSION = 20
+  VERSION = 21
 
   # Jekyll and related dependency versions as used by GitHub Pages.
   # For more information see:
@@ -16,7 +16,7 @@ class GitHubPages
       "jemoji"               => "0.1.0",
       "jekyll-mentions"      => "0.0.9",
       "jekyll-redirect-from" => "0.3.1",
-      "jekyll-sitemap"       => "0.3.0",
+      "jekyll-sitemap"       => "0.5.0",
     }
   end
 


### PR DESCRIPTION
Jekyll-sitemap has released a 0.5.0 version:
http://rubygems.org/gems/jekyll-sitemap

The best feature of the new version is you can now exclude sites from the sitemap. This comes in handy for custom 404 pages on Github:

```

---
title: 404
layout: default
permalink: /404.html
sitemap: false

---
```

Here is the corresponding code: https://github.com/jekyll/jekyll-sitemap/blob/v0.5.0/lib/sitemap.xml#L11

All changes:
https://github.com/jekyll/jekyll-sitemap/compare/v0.3.0...v0.5.0

Changelog:
https://github.com/jekyll/jekyll-sitemap/blob/v0.5.0/History.markdown
