### PR TITLE
Upgrade to Maruku 0.7.2

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -9,7 +9,7 @@ class GitHubPages
       "jekyll"               => "1.5.1",
       "kramdown"             => "1.3.1",
       "liquid"               => "2.5.5",
-      "maruku"               => "0.7.0",
+      "maruku"               => "0.7.2",
       "rdiscount"            => "2.1.7",
       "redcarpet"            => "2.3.0",
       "RedCloth"             => "4.2.9",


### PR DESCRIPTION
Maruku has had two maintenance releases since 0.7.0: https://github.com/bhollis/maruku/blob/master/CHANGELOG.md

These are backwards-compatible bugfix releases.
