### PR TITLE
Add rouge as an alternative to pygments (Jekyll 2.x)

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -21,6 +21,9 @@ class GitHubPages
       # Liquid
       "liquid"               => "2.6.1",
 
+      # Highlighters
+      "rouge"                => "1.5.1",
+
       # Plugins
       "jemoji"               => "0.2.0",
       "jekyll-mentions"      => "0.1.2",


### PR DESCRIPTION
Jekyll 2 supports https://github.com/jneen/rouge hightlighter as an alternative to pygments.
This change adds current version of rouge (1.5.1) to github-pages.

**Backlog and known issues:**
- [ ] #75 Upgrade to Jekyll 2.1
- [ ] jekyll/jekyll#2607 Invalid highlight html with rouge and linenos
