### PR TITLE
Bump jekyll-sitemap to v0.5.1

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -28,7 +28,7 @@ class GitHubPages
       "jemoji"                => "0.3.0",
       "jekyll-mentions"       => "0.1.3",
       "jekyll-redirect-from"  => "0.4.0",
-      "jekyll-sitemap"        => "0.5.0",
+      "jekyll-sitemap"        => "0.5.1",
     }
   end
 


### PR DESCRIPTION
v0.5.1 prevents a warning message in Jekyll 2.2.0. Nothing drastic. This change just means people using `github-pages` locally won't be so confused.

/cc @benbalter 
