### PR TITLE
Update to jekyll-sass-converter to v1.2.0.

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -9,7 +9,7 @@ class GitHubPages
       # Jekyll
       "jekyll"                => "2.2.0",
       "jekyll-coffeescript"   => "1.0.0",
-      "jekyll-sass-converter" => "1.1.0",
+      "jekyll-sass-converter" => "1.2.0",
 
       # Converters
       "kramdown"              => "1.3.1",


### PR DESCRIPTION
This version allows for users to set a custom output style in safe mode.
- https://github.com/jekyll/jekyll-sass-converter/releases/tag/v1.2.0
- https://github.com/jekyll/jekyll-sass-converter/compare/v1.1.0...v1.2.0
- https://github.com/jekyll/jekyll-sass-converter/pull/16
