### PR TITLE
Bump jekyll-redirect-from to v0.5.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -27,7 +27,7 @@ class GitHubPages
       # Plugins
       "jemoji"                => "0.3.0",
       "jekyll-mentions"       => "0.1.3",
-      "jekyll-redirect-from"  => "0.4.0",
+      "jekyll-redirect-from"  => "0.5.0",
       "jekyll-sitemap"        => "0.5.1",
     }
   end


### PR DESCRIPTION
Support new `redirect_to` directive. Now automatically prefixes URLs with `site.github.url`, or `site.baseurl`, with that order of precedence.

Release: https://github.com/jekyll/jekyll-redirect-from/releases/tag/v0.5.0
Diff: https://github.com/jekyll/jekyll-redirect-from/compare/v0.4.0...v0.5.0
