### PR TITLE
Bump Jekyll to v2.3.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -7,7 +7,7 @@ class GitHubPages
   def self.gems
     {
       # Jekyll
-      "jekyll"                => "2.2.0",
+      "jekyll"                => "2.3.0",
       "jekyll-coffeescript"   => "1.0.0",
       "jekyll-sass-converter" => "1.2.0",
 


### PR DESCRIPTION
https://github.com/jekyll/jekyll/releases/tag/v2.3.0
https://github.com/jekyll/jekyll/compare/v2.2.0...v2.3.0

@benbalter, this should solve some support tickets.
