### PR TITLE
Bump jekyll-redirect-from to 0.6.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -27,7 +27,7 @@ class GitHubPages
       # Plugins
       "jemoji"                => "0.3.0",
       "jekyll-mentions"       => "0.1.3",
-      "jekyll-redirect-from"  => "0.4.0",
+      "jekyll-redirect-from"  => "0.6.0",
       "jekyll-sitemap"        => "0.5.1",
     }
   end


### PR DESCRIPTION
Bumping from `0.4.0` to `0.6.0`. Release notes for each version:
- [`v0.5.0`](https://github.com/jekyll/jekyll-redirect-from/releases/tag/v0.5.0)
- [`v0.6.0`](https://github.com/jekyll/jekyll-redirect-from/releases/tag/v0.6.0)

The full diff: https://github.com/jekyll/jekyll-redirect-from/compare/v0.4.0...v0.6.0

Nothing I can identify that would be a security concern. The only new functionality:
1. Preface the URL in the HTML (doesn't affect the output directory/filename) with `site.baseurl` or `site.github.url`
2. Gives collection documents access to existing functionality (nothing new here)

/cc @gjtorikian @kansaichris @benbalter @github/security
