### PR TITLE
Bump sitemap :gem: to 0.6.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -28,7 +28,7 @@ class GitHubPages
       "jemoji"                => "0.3.0",
       "jekyll-mentions"       => "0.1.3",
       "jekyll-redirect-from"  => "0.6.0",
-      "jekyll-sitemap"        => "0.5.1",
+      "jekyll-sitemap"        => "0.6.0",
     }
   end
 


### PR DESCRIPTION
https://github.com/jekyll/jekyll-sitemap/releases/tag/v0.6.0

Updates the sitemap template with collection and last_modified support
