### PR TITLE
Bump to jekyll-redirect-from v0.6.2

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -27,7 +27,7 @@ class GitHubPages
       # Plugins
       "jemoji"                => "0.3.0",
       "jekyll-mentions"       => "0.1.3",
-      "jekyll-redirect-from"  => "0.6.0",
+      "jekyll-redirect-from"  => "0.6.1",
       "jekyll-sitemap"        => "0.6.0",
     }
   end


### PR DESCRIPTION
  Fix for if `site.github` isn't a `Hash` when trying to access `site.github.url`.

Only affects those who have set `github` in their site `_config.yml`'s but it will cause build failures galore.

_Veeery small diff_: https://github.com/jekyll/jekyll-redirect-from/compare/v0.6.0...v0.6.1

Release: https://github.com/jekyll/jekyll-redirect-from/releases/tag/v0.6.1

Release numero dos: https://github.com/jekyll/jekyll-redirect-from/releases/tag/v0.6.2

/cc @kansaichris @mastahyeti @benbalter
