### PR TITLE
Bump to Jekyll 2.4.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -7,7 +7,7 @@ class GitHubPages
   def self.gems
     {
       # Jekyll
-      "jekyll"                => "2.3.0",
+      "jekyll"                => "2.4.0",
       "jekyll-coffeescript"   => "1.0.0",
       "jekyll-sass-converter" => "1.2.0",
 


### PR DESCRIPTION
Release: https://github.com/jekyll/jekyll/releases/tag/v2.4.0
Diff: https://github.com/jekyll/jekyll/compare/v2.3.0...v2.4.0 (all the important stuff is in `lib/`, the rest is testing/documentation)
Co-sponsored by @gjtorikian and @kansaichris who put a LOT of work into this.

With love from SF.

/cc @benbalter @mastahyeti @ptoomey3 @gregose
