### PR TITLE
Actually bump jekyll-redirect-from to 0.6.2

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -27,7 +27,7 @@ class GitHubPages
       # Plugins
       "jemoji"                => "0.3.0",
       "jekyll-mentions"       => "0.1.3",
-      "jekyll-redirect-from"  => "0.6.1",
+      "jekyll-redirect-from"  => "0.6.2",
       "jekyll-sitemap"        => "0.6.0",
     }
   end


### PR DESCRIPTION
Although the title was changed in https://github.com/github/pages-gem/pull/90, I didn't notice that the `jekyll-redirect-from` gem was not actually bumped to 0.6.2.
