### PR TITLE
Update to jekyll-sitemap v0.6.1

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -28,7 +28,7 @@ class GitHubPages
       "jemoji"                => "0.3.0",
       "jekyll-mentions"       => "0.1.3",
       "jekyll-redirect-from"  => "0.6.2",
-      "jekyll-sitemap"        => "0.6.0",
+      "jekyll-sitemap"        => "0.6.1",
     }
   end
 


### PR DESCRIPTION
3 changes, only 2 affect runtime code:
1. Strip whitespace from output
2. Use `date_to_xmlschema` instead of a custom date format for `lastmod`

https://github.com/jekyll/jekyll-sitemap/releases/tag/v0.6.1
https://github.com/jekyll/jekyll-sitemap/compare/v0.6.0...v0.6.1

:chocolate_bar:

/cc @benbalter 
