### PR TITLE
Bump coffee-script dependency to 1.0.1

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -8,7 +8,7 @@ class GitHubPages
     {
       # Jekyll
       "jekyll"                => "2.4.0",
-      "jekyll-coffeescript"   => "1.0.0",
+      "jekyll-coffeescript"   => "1.0.1",
       "jekyll-sass-converter" => "1.2.0",
 
       # Converters


### PR DESCRIPTION
I'm getting some Bundler issues trying to use the github-pages gem and jemoji:

```
Bundler could not find compatible versions for gem "jekyll-coffeescript":
  In Gemfile:
    github-pages (>= 0) ruby depends on
      jekyll-coffeescript (= 1.0.0) ruby

    jemoji (= 0.3.0) ruby depends on
      jekyll (~> 2.0) ruby depends on
        jekyll-coffeescript (1.0.1)

Bundler could not find compatible versions for gem "jekyll":
  In Gemfile:
    github-pages (>= 0) ruby depends on
      jekyll (= 1.1.2) ruby

    jemoji (= 0.3.0) ruby depends on
      jekyll (2.4.0)
```

I believe this'll resolve that? /cc @benbalter @parkr 
