### PR TITLE
Bump Jekyll to v2.5.2

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -7,7 +7,7 @@ class GitHubPages
   def self.gems
     {
       # Jekyll
-      "jekyll"                => "2.4.0",
+      "jekyll"                => "2.5.0",
       "jekyll-coffeescript"   => "1.0.1",
       "jekyll-sass-converter" => "1.2.0",
 

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -7,7 +7,7 @@ class GitHubPages
   def self.gems
     {
       # Jekyll
-      "jekyll"                => "2.5.0",
+      "jekyll"                => "2.5.2",
       "jekyll-coffeescript"   => "1.0.1",
       "jekyll-sass-converter" => "1.2.0",
 


### PR DESCRIPTION
Release post: http://jekyllrb.com/news/2014/11/05/jekylls-midlife-crisis-jekyll-turns-2-5-0/
GitHub Release: https://github.com/jekyll/jekyll/releases/tag/v2.5.0
Diff: https://github.com/jekyll/jekyll/compare/v2.4.0...v2.5.0

Security should be happy with this: all path sanitation is centralized now.
See https://github.com/jekyll/jekyll/pull/2882 for more info.

Also be sure to set `JEKYLL_NO_BUNDLER_REQUIRE=true` in your environment.

This PR also includes v2.5.1 and v2.5.2, both of which are small releases.

v2.5.1 was a path sanitation bug fix for Windows users.
v2.5.2 was a fix for that fix and a fix for Bundler woes.

- v2.5.1 diff: https://github.com/jekyll/jekyll/compare/v2.5.0...v2.5.1
- v2.5.1 release: https://github.com/jekyll/jekyll/releases/tag/v2.5.1
- v2.5.2 diff: https://github.com/jekyll/jekyll/compare/v2.5.1...v2.5.2
- v2.5.2 release: https://github.com/jekyll/jekyll/releases/tag/v2.5.2

/cc @benbalter @mastahyeti @gjtorikian @gregose @spraints 