### PR TITLE
Update to jekyll-sitemap v0.6.3

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -28,7 +28,7 @@ class GitHubPages
       "jemoji"                => "0.3.0",
       "jekyll-mentions"       => "0.1.3",
       "jekyll-redirect-from"  => "0.6.2",
-      "jekyll-sitemap"        => "0.6.2",
+      "jekyll-sitemap"        => "0.6.3",
     }
   end
 


### PR DESCRIPTION
Replaces #95.

5 changes, only 4 affect runtime code:
1. Strip whitespace from output
2. Use `date_to_xmlschema` instead of a custom date format for `lastmod`
3. Create a subclass of `Page` which does not attempt to read from the file system
4. Use `Site#in_source_dir` and `Site#in_dest_dir` per Jekyll v2.5.0 (or falls back to old method if Jekyll version is < 2.5)

https://github.com/jekyll/jekyll-sitemap/releases/tag/v0.6.1
https://github.com/jekyll/jekyll-sitemap/releases/tag/v0.6.2
https://github.com/jekyll/jekyll-sitemap/releases/tag/v0.6.3
https://github.com/jekyll/jekyll-sitemap/compare/v0.6.0...v0.6.3

:chocolate_bar:

/cc @benbalter @mastahyeti @gregose @ptoomey3 @gjtorikian @spraints 
