### PR TITLE
Bump health check :gem: to 0.2.1

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     s.add_dependency(gem, "= #{version}")
   end
 
-  s.add_dependency('github-pages-health-check', "~> 0.1")
+  s.add_dependency('github-pages-health-check', "~> 0.2")
   s.add_dependency('mercenary', "~> 0.3")
   s.add_dependency('terminal-table', "~> 1.4")
   s.add_development_dependency("rspec", "~> 2.14")


### PR DESCRIPTION
It now checks that [domains resolve to the Pages server](https://github.com/github/pages-health-check/releases/tag/v0.2.0)
