### PR TITLE
Bump jemoji to v0.4.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -25,7 +25,7 @@ class GitHubPages
       "pygments.rb"           => "0.6.0",
 
       # Plugins
-      "jemoji"                => "0.3.0",
+      "jemoji"                => "0.4.0",
       "jekyll-mentions"       => "0.1.3",
       "jekyll-redirect-from"  => "0.6.2",
       "jekyll-sitemap"        => "0.6.3",


### PR DESCRIPTION
This release brings emoji to collection documents. The only important file is `lib/jemoji.rb`.
- Diff: https://github.com/jekyll/jemoji/compare/v0.3.0...v0.4.0
- Release: https://github.com/jekyll/jemoji/releases/tag/v0.4.0

/cc @gjtorikian, who wrote the beautiful code
