### PR TITLE
Bump jekyll-mentions to v0.2.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -26,7 +26,7 @@ class GitHubPages
 
       # Plugins
       "jemoji"                => "0.3.0",
-      "jekyll-mentions"       => "0.1.3",
+      "jekyll-mentions"       => "0.2.0",
       "jekyll-redirect-from"  => "0.6.2",
       "jekyll-sitemap"        => "0.6.3",
     }


### PR DESCRIPTION
This brings mentions to collection documents.
- Release: https://github.com/jekyll/jekyll-mentions/releases/tag/v0.2.0
- Diff: https://github.com/jekyll/jekyll-mentions/compare/v0.1.3...v0.2.0

/cc @gjtorikian who wrote the beautiful code
