### PR TITLE
Feature Request: Add Jekyll Archives on GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ $ github-pages versions
 | liquid                | 2.6.1   |
 | pygments.rb           | 0.6.0   |
 | jemoji                | 0.3.0   |
+| jekyll-archives       | 1.0.0   |
 | jekyll-mentions       | 0.1.3   |
 | jekyll-redirect-from  | 0.6.2   |
 | jekyll-sitemap        | 0.6.0   |

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -26,6 +26,7 @@ class GitHubPages
 
       # Plugins
       "jemoji"                => "0.3.0",
+      "jekyll-archives"       => "1.0.0",
       "jekyll-mentions"       => "0.1.3",
       "jekyll-redirect-from"  => "0.6.2",
       "jekyll-sitemap"        => "0.6.3",


### PR DESCRIPTION
As mentioned in #93, we *really* hope Github Pages can support generating tags/categories/archives pages for blog. This is a such basic and fundamental feature we like to have without building the site locally.

This PR adds [the Jekyll official plugin `jekyll-archives`](https://github.com/jekyll/jekyll-archives) into the dependency list.