### PR TITLE
Bump mentions to two-dot-oh

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -1,5 +1,5 @@
 class GitHubPages
-  VERSION = 30
+  VERSION = 31
 
   # Jekyll and related dependency versions as used by GitHub Pages.
   # For more information see:
@@ -26,7 +26,7 @@ class GitHubPages
 
       # Plugins
       "jemoji"                => "0.4.0",
-      "jekyll-mentions"       => "0.2.0",
+      "jekyll-mentions"       => "0.2.1",
       "jekyll-redirect-from"  => "0.6.2",
       "jekyll-sitemap"        => "0.6.3",
     }


### PR DESCRIPTION
This updates jekyll-mentions to the closest patch, which addressed a bug: https://github.com/jekyll/jekyll-mentions/pull/20.
