### PR TITLE
Bump kramdown to 1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ github-pages versions
 | jekyll                | 2.4.0   |
 | jekyll-coffeescript   | 1.0.0   |
 | jekyll-sass-converter | 1.2.0   |
-| kramdown              | 1.3.1   |
+| kramdown              | 1.5.0   |
 | maruku                | 0.7.0   |
 | rdiscount             | 2.1.7   |
 | redcarpet             | 3.1.2   |

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -12,7 +12,7 @@ class GitHubPages
       "jekyll-sass-converter" => "1.2.0",
 
       # Converters
-      "kramdown"              => "1.3.1",
+      "kramdown"              => "1.5.0",
       "maruku"                => "0.7.0",
       "rdiscount"             => "2.1.7",
       "redcarpet"             => "3.1.2",


### PR DESCRIPTION
kramdown 1.5.0 adds support for [Rouge](https://github.com/jneen/rouge) as a syntax highlighter and new math engines. The currently required version 1.3.1 was released more than a year ago at this point, so I think it's okay to update. No breaking changes have been introduced since then.

For more information, see: http://kramdown.gettalong.org/news.html