### PR TITLE
Upgrade jekyll-sitemap to v0.8.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -28,7 +28,7 @@ class GitHubPages
       "jemoji"                => "0.4.0",
       "jekyll-mentions"       => "0.2.1",
       "jekyll-redirect-from"  => "0.6.2",
-      "jekyll-sitemap"        => "0.6.3",
+      "jekyll-sitemap"        => "0.8.0",
     }
   end
 


### PR DESCRIPTION
*Very* small update.

v0.8.0: https://github.com/jekyll/jekyll-sitemap/releases/tag/v0.8.0
v0.7.0 (skipped): https://github.com/jekyll/jekyll-sitemap/releases/tag/v0.7.0

Highlights:

- `baseurl` fixes
- remove `priority`
- remove `changefreq`
- fix for filenames which end in `index.html`

/cc @gjtorikian @benbalter 