### PR TITLE
Add dependency on jekyll-last-modified-at

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -25,10 +25,11 @@ class GitHubPages
       "pygments.rb"           => "0.6.1",
 
       # Plugins
-      "jemoji"                => "0.4.0",
-      "jekyll-mentions"       => "0.2.1",
-      "jekyll-redirect-from"  => "0.6.2",
-      "jekyll-sitemap"        => "0.6.3",
+      "jemoji"                  => "0.4.0",
+      "jekyll-mentions"         => "0.2.1",
+      "jekyll-redirect-from"    => "0.6.2",
+      "jekyll-sitemap"          => "0.6.3",
+      "jekyll-last-modified-at" => "0.3.4"
     }
   end
 


### PR DESCRIPTION
Add jekyll-last-modified-at to make it easier to time stamp built pages.  Currently this requires us to do a static build locally, but it seems like a feature that would be widely used.
