### PR TITLE
Drop Ruby 1.9.3 support.

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -1,7 +1,7 @@
 require File.expand_path('../lib/github-pages', __FILE__)
 
 Gem::Specification.new do |s|
-  s.required_ruby_version = ">= 1.9.3"
+  s.required_ruby_version = ">= 2.0.0"
 
   s.name                  = "github-pages"
   s.version               = GitHubPages::VERSION


### PR DESCRIPTION
>`public_suffix`, a dependency of `github-pages-health-check`, now mandates Ruby > 2.0.

Fixes #122.

/CC @benbalter @gjtorikian 