### PR TITLE
update liquid to 2.6.2

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -19,7 +19,7 @@ class GitHubPages
       "RedCloth"              => "4.2.9",
 
       # Liquid
-      "liquid"                => "2.6.1",
+      "liquid"                => "2.6.2",
 
       # Highlighters
       "pygments.rb"           => "0.6.1",


### PR DESCRIPTION
- experiencing Shopify/liquid#502 with 2.6.1; a fix for this issue was in 2.6.2