### PR TITLE
Bump jekyll-redirect-from to v0.8.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -27,7 +27,7 @@ class GitHubPages
       # Plugins
       "jemoji"                => "0.4.0",
       "jekyll-mentions"       => "0.2.1",
-      "jekyll-redirect-from"  => "0.6.2",
+      "jekyll-redirect-from"  => "0.8.0",
       "jekyll-sitemap"        => "0.8.1",
     }
   end


### PR DESCRIPTION
v0.8.0 fixes a problem where redirect pages showed up in the sitemap: https://github.com/jekyll/jekyll-sitemap/issues/75

29 commits: https://github.com/jekyll/jekyll-redirect-from/compare/v0.6.2...v0.8.0
v0.7.0: https://github.com/jekyll/jekyll-redirect-from/releases/tag/v0.7.0
v0.8.0: https://github.com/jekyll/jekyll-redirect-from/releases/tag/v0.8.0

/cc @benbalter @gjtorikian @pathawks