### PR TITLE
Bump redcarpet@3.2.2

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -15,7 +15,7 @@ class GitHubPages
       "kramdown"              => "1.5.0",
       "maruku"                => "0.7.0",
       "rdiscount"             => "2.1.7",
-      "redcarpet"             => "3.2.2",
+      "redcarpet"             => "3.3.0",
       "RedCloth"              => "4.2.9",
 
       # Liquid

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -15,7 +15,7 @@ class GitHubPages
       "kramdown"              => "1.5.0",
       "maruku"                => "0.7.0",
       "rdiscount"             => "2.1.7",
-      "redcarpet"             => "3.1.2",
+      "redcarpet"             => "3.2.2",
       "RedCloth"              => "4.2.9",
 
       # Liquid


### PR DESCRIPTION
This bumps the version of `redcarpet` as to include changes (not limited to, I'm sure) for stripping non-alphanumeric characters from header ids. :pizza: 