### PR TITLE
Upgrade pygments.rb from 0.6.1 to 0.6.3

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -22,7 +22,7 @@ class GitHubPages
       "liquid"                => "2.6.2",
 
       # Highlighters
-      "pygments.rb"           => "0.6.1",
+      "pygments.rb"           => "0.6.3",
 
       # Plugins
       "jemoji"                => "0.4.0",


### PR DESCRIPTION
Not _entirely_ sure what's happened since 0.6.1 since 0.6.1 doesn't have a tag and there are no release notes in the changelog or in the GitHub Releases. If we base it off of the commit where v0.6.0 is created (I usually do this last when working on a gem release, not sure if tmm1 is the same), then we have:

https://github.com/tmm1/pygments.rb/compare/f6dceb2d9c94b93d99908c6694de049f84b90983...v0.6.3

Appears to:

1. bump `yajl-ruby` from `~> 1.1.0` to `~> 1.2.0`
2. Force `MENTOS_TIMEOUT` env var to be an `Integer` to determine timeout for subprocess
3. Reads lexer file as `rb` instead of `r`
4. Fixes discovery of `py` executable for Windows

Fixes #144 

/cc @benbalter 