### PR TITLE
Bumped Redcarpet to 3.3.2

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -15,7 +15,7 @@ class GitHubPages
       "kramdown"              => "1.5.0",
       "maruku"                => "0.7.0",
       "rdiscount"             => "2.1.7",
-      "redcarpet"             => "3.3.1",
+      "redcarpet"             => "3.3.2",
       "RedCloth"              => "4.2.9",
 
       # Liquid


### PR DESCRIPTION
Versions 3.3.2 has a fix for a potential security issue in the HTML renderer