### PR TITLE
Bumped Rdiscount to 2.1.8

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -14,7 +14,7 @@ class GitHubPages
       # Converters
       "kramdown"              => "1.5.0",
       "maruku"                => "0.7.0",
-      "rdiscount"             => "2.1.7",
+      "rdiscount"             => "2.1.8",
       "redcarpet"             => "3.3.2",
       "RedCloth"              => "4.2.9",
 


### PR DESCRIPTION
These are the changes bumping the version will bring:

2.1.8
* Compatible with Ruby 1.2.0.
+* Discount upgraded from 2.1.7 -> 2.1.8
+    * GitHub-style language attributes on fenced code blocks.
+    * Long numeric list items.
+    * Fix footnote numbering inside of nested elements.
+    * Fix a bug where autolink + github flavored markdown absorbs the ^C eoln character into a link at the end of a line.

2.1.7.1
* Compatible with Xcode 5.1's clang on OS X.
