### PR TITLE
Bumped Jekyll-Sass-Converter to 1.3.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -9,7 +9,7 @@ class GitHubPages
       # Jekyll
       "jekyll"                => "2.4.0",
       "jekyll-coffeescript"   => "1.0.1",
-      "jekyll-sass-converter" => "1.2.0",
+      "jekyll-sass-converter" => "1.3.0",
 
       # Converters
       "kramdown"              => "1.5.0",


### PR DESCRIPTION
Changes added by increasing the version number.

1.3.0
Include line number in syntax error message
Raise a Jekyll::Converters::Scss::SyntaxError instead of just a StandardError

1.2.1
Only include something in the sass load path if it exists