### PR TITLE
Bumped Jekyll-Feed to 0.3.1

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -29,7 +29,7 @@ class GitHubPages
       "jekyll-mentions"       => "0.2.1",
       "jekyll-redirect-from"  => "0.8.0",
       "jekyll-sitemap"        => "0.8.1",
-      "jekyll-feed"           => "0.3.0",
+      "jekyll-feed"           => "0.3.1",
     }
   end
 


### PR DESCRIPTION
Updating to this version will add the following fix:

Check to ensure the post excerpt isn't blank before outputting
