### PR TITLE
Bumped Maruku to 0.7.2

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -13,7 +13,7 @@ class GitHubPages
 
       # Converters
       "kramdown"              => "1.5.0",
-      "maruku"                => "0.7.0",
+      "maruku"                => "0.7.2",
       "rdiscount"             => "2.1.7",
       "redcarpet"             => "3.3.1",
       "RedCloth"              => "4.2.9",


### PR DESCRIPTION
0.7.2
Updated signing certificate

0.7.1
*Improve the escaping of script and style tags with CDATA blocks. CDATA is now only added when necessary, ugly remnants are avoided when CDATA is already present, and best of all our HTML handling code is significantly simplified.
*Solidly fix parsing HTML inside a paragraph (or simply up against it without a blank line) not parsing correctly. Also, remove an ineffective hack to handle inline HTML that involved parsing the HTML twice.
*Rewrite pick_apart_non_inline_html in a non-functional style because Enumerable#chunk is not available in Ruby 1.8.7
*Removed wasteful debug printing
