### PR TITLE
Bumped Kramdown to 1.9.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -12,7 +12,7 @@ class GitHubPages
       "jekyll-sass-converter" => "1.3.0",
 
       # Converters
-      "kramdown"              => "1.5.0",
+      "kramdown"              => "1.9.0",
       "maruku"                => "0.7.0",
       "rdiscount"             => "2.1.7",
       "redcarpet"             => "3.3.2",


### PR DESCRIPTION
Changes that come with updating from 1.5.0 to 1.9.0

Changes from 1.9.0

* 10 changes:
  - Updated Rakefile to fix website generation
  - Simplified AST converter and renamed it to HashAST
  - Implements an Abstract Syntax Tree converter that returns a Ruby hash
  - If the footnote_backlink option is empty, no backlinks will be created
  - Added line location test for GFM parser with hard wrapped paragraphs
  - Added missing location to elements created while using hard_wrap option.
  - Enhanced rouge syntax highlighter to allow separate span/block options
  - Fixed testing script
  - Mentioned in Rouge docs that Rouge options are supported, too
  - Added link to the news page with change information in the readme

Changes from 1.8.0

* 4 minor changes:

  - The LaTeX converter now uses `\texttt` instead of `\tt` for code spans (fixes [#257], reported
    by richard101696)
  - New option `footnote_backlink` for changing the backlink of footnotes in the HTML converter
    (fixes [#247], requested by Benjamin Esham)
  - A quote directly followed by an ellipsis is now converted into an opening quotation mark (fixes
    [#253], requested by Michael Franzl)
  - Removed warning for self-closing HTML elements that are not self-closed (fixes [#262], requested
    by Gregory Pakosz)

* 3 bug fixes:

  - Fixed [#251]: The special character sequence `` \` `` now works correctly when used in footnotes
    or headers that appear in the table of contents (reported by Peter Kehl)
  - Fixed [#254]: kramdown crashed on encountering a table with multiple consecutive separator lines
    (reported by Christian Kruse)
  - Fixed [#256]: Certain footnote definitions and codeblocks lead to crashes or unneeded
    backtracking in the regular expression engine - fixed by using atomic grouping (reported by Ali
    Ok)

[#251]: https://github.com/gettalong/kramdown/issues/251
[#257]: https://github.com/gettalong/kramdown/issues/257
[#247]: https://github.com/gettalong/kramdown/issues/247
[#254]: https://github.com/gettalong/kramdown/issues/254
[#256]: https://github.com/gettalong/kramdown/issues/256
[#253]: https://github.com/gettalong/kramdown/issues/253
[#262]: https://github.com/gettalong/kramdown/issues/262

Changes from 1.7.0

This release brings among other things support for the ‘minted’ syntax highlighter for LaTeX and a new math engine based on MathJax-Node that outputs to MathML.

* 4 minor changes:

  - The syntax highlighter ['minted'](../syntax_highlighter/minted.html) for the [LaTeX
    converter](../converter/latex.html) is now available (fixes issue [#93], initial patch [#242] by
    l3kn)
  - A new [math engine based on MathJax-Node](../math_engine/mathjaxnode.html) that outputs to
    MathML is now available (patch [#240] by Tom Thorogood)
  - Fixed [#244], [#246]: Fenced code blocks now allow a dash in the code language name (requested
    and patched by Dennis Günnewig)
  - The option list in the man page as well in the output of `kramdown --help` is now sorted.

* 2 bug fixes:

  - Fixed [#230]: Warning message for method in `lib/kramdown/utils/configurable.rb` will not show
    anymore (reported by Robert A. Heiler)
  - Fixed [#239]: Handling of single/double quotes in reference style links now follows the same
    rules as with inline links (reported by Josh Davis)

[#230]: https://github.com/gettalong/kramdown/issues/230
[#239]: https://github.com/gettalong/kramdown/issues/239
[#244]: https://github.com/gettalong/kramdown/issues/244
[#246]: https://github.com/gettalong/kramdown/pull/246
[#240]: https://github.com/gettalong/kramdown/pull/240
[#93]: https://github.com/gettalong/kramdown/issues/93
[#242]: https://github.com/gettalong/kramdown/pull/242

Changes from 1.6.0

This release contains many fixes and minor enhancements as well as one major goodie that comes with a small caveat: block IALs can now be applied to link and abbreviation definitions!

It may not sound like much but allowing block IALs to be applied to link definitions alleviates the problem that additional attributes could only be specified via span IALs. Now such attributes can be stored together with the URL and title at the link definition

* 7 minor changes:

  - Block IALs can now be applied to link and abbreviation definitions (inspired by issue [#194]
    from cabo)
  - The syntax highlighting engine for Rouge now allows custom formatter classes to be used (issue
    [#214], requested by BackOrder)
  - The MathJax math engine now allows adding previews (issue [#225], requested by jethrogb)
  - The "toc_levels" option can now also take a Range object (pull request [#210] by Jens Krämer)
  - The generated table of contents of the HTML converter now contains ID attributes on the links so
    that back-references can be used (issue [#195], requested by Ciro Santilli)
  - A warning is now generated when duplicate HTML attributes are detected (issue [#201], requested
    by winniehell)
  - Updated used version of prawn to 2.0.0

* 8 bug fixes:

  - Fixed [#192]: Emphasis by using underscore sometimes wrongly worked within a word (reported by
    Michael Franzl)
  - Fixed [#198]: Empty alt attributes on `<img>` tags are now correctly handled by the kramdown
    converter (reported by winniehell)
  - Fixed [#200]: Trailing whitespace is now really removed in paragraphs (reported by winniehell)
  - Fixed [#220]: HTML blocks with attributes weren't correctly detected when directly after another
    block (reported by Bill Tozier)
  - Fixed [#199]: Empty title attributes are now ignored for images when using the kramdown
    converter (reported by and pull request [#206] from winniehell)
  - Leading and trailing white space from math statements is now stripped as the whitespace
    sometimes lead to LaTeX conversion errors
  - Fixed [#226]: Class names may now start with a dash in IALs/ALDs (reported by Adam Hardwick)
  - Multiple consecutive block IALs before an element are now correctly processed

[#192]: https://github.com/gettalong/kramdown/issues/192
[#198]: https://github.com/gettalong/kramdown/issues/198
[#200]: https://github.com/gettalong/kramdown/issues/200
[#201]: https://github.com/gettalong/kramdown/issues/201
[#214]: https://github.com/gettalong/kramdown/issues/214
[#210]: https://github.com/gettalong/kramdown/pull/210
[#195]: https://github.com/gettalong/kramdown/issues/195
[#220]: https://github.com/gettalong/kramdown/issues/220
[#199]: https://github.com/gettalong/kramdown/issues/199
[#206]: https://github.com/gettalong/kramdown/pull/206
[#225]: https://github.com/gettalong/kramdown/issues/225
[#226]: https://github.com/gettalong/kramdown/issues/226
[#194]: https://github.com/gettalong/kramdown/issues/194