### PR TITLE
Bumped Jemoji to 0.5.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -25,7 +25,7 @@ class GitHubPages
       "pygments.rb"           => "0.6.3",
 
       # Plugins
-      "jemoji"                => "0.4.0",
+      "jemoji"                => "0.5.0",
       "jekyll-mentions"       => "0.2.1",
       "jekyll-redirect-from"  => "0.8.0",
       "jekyll-sitemap"        => "0.8.1",


### PR DESCRIPTION
Prepares Jemoji to support Jekyll 3
Travis: add 2.2 to build matrix, remove 1.9.3, only master branch build