### PR TITLE
Bumped Rspec to 3.3.0

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_dependency('github-pages-health-check', "~> 0.2")
   s.add_dependency('mercenary', "~> 0.3")
   s.add_dependency('terminal-table', "~> 1.4")
-  s.add_development_dependency("rspec", "~> 2.14")
+  s.add_development_dependency("rspec", "~> 3.3")
 end


### PR DESCRIPTION
3.3.0 Changes
Removed deprecated option from .gemspec 
Updated README.md

3.2.0 Changes
Add the new signing certificates

3.1.0 Changes
Same as 3.0.0

3.0.0 Changes

Added public cert for signing
Replaced deprecated File.exists with File.exist as of Ruby 2.1
Setup gem signing
Uses rspec-support from the local dev directory
Don't explicitly require mocks and expectations upfront