### PR TITLE
Bundle health-check in github-pages.rb

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
     s.add_dependency(gem, "= #{version}")
   end
 
-  s.add_dependency('github-pages-health-check', "~> 0.2")
   s.add_dependency('mercenary', "~> 0.3")
   s.add_dependency('terminal-table', "~> 1.4")
   s.add_development_dependency("rspec", "~> 3.3")

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -30,6 +30,7 @@ class GitHubPages
       "jekyll-redirect-from"  => "0.8.0",
       "jekyll-sitemap"        => "0.9.0",
       "jekyll-feed"           => "0.3.1",
+      "github-pages-health-check" => "0.3.1",
     }
   end
 


### PR DESCRIPTION
So they can be easily updated in one file instead of having to update two files. The versions have remained the same as found in release v38

