### PR TITLE
Add Rouge support

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -1,5 +1,5 @@
 class GitHubPages
-  VERSION = 38
+  VERSION = 39
 
   # Jekyll and related dependency versions as used by GitHub Pages.
   # For more information see:
@@ -23,6 +23,7 @@ class GitHubPages
 
       # Highlighters
       "pygments.rb"           => "0.6.3",
+      "rouge"                 => "1.9.0",
 
       # Plugins
       "jemoji"                => "0.4.0",

--- a/spec/github-pages_spec.rb
+++ b/spec/github-pages_spec.rb
@@ -15,7 +15,7 @@ describe(GitHubPages) do
     expect(described_class.versions).to include("github-pages")
   end
 
-  %w[jekyll kramdown liquid maruku rdiscount redcarpet RedCloth].each do |gem|
+  %w[jekyll kramdown liquid maruku rdiscount redcarpet RedCloth rouge].each do |gem|
     it "exposes #{gem} dependency version" do
       expect(described_class.gems[gem]).to be_a(String)
       expect(described_class.gems[gem]).not_to be_empty


### PR DESCRIPTION
Pygments is fine, but I like using fenced code blocks rather than highlight liquid tags. Fenced blocks are nicely highlighted by Atom in the source code, and can be rendered by kramdown+rouge using the same Pygment styles.