### PR TITLE
Bumped Jekyll to 2.5.3

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -7,7 +7,7 @@ class GitHubPages
   def self.gems
     {
       # Jekyll
-      "jekyll"                => "2.4.0",
+      "jekyll"                => "2.5.3",
       "jekyll-coffeescript"   => "1.0.1",
       "jekyll-sass-converter" => "1.3.0",
 


### PR DESCRIPTION
I know the GitHub folks may be waiting for 3.0.0 of Jekyll to be released. Just figured this couldn't hurt just to add this.

2.5.3 Changes

Bug Fixes

    When checking a Markdown extname, include position of the .
    Fix jsonify Liquid filter handling of boolean values
    Add comma to value of viewport meta tag
    Set the link type for the RSS feed to application/rss+xml
    Refactor #as_liquid

Development Fixes

    Exclude built-in bundles from being added to coverage report

Site Enhancements

    Add @alfredxing to the @jekyll/core team. :tada:
    Document the -q option for the build and serve commands
    Fix some minor typos/flow fixes in documentation website content
    Add keep_files to configuration documentation
    Repeat warning about cleaning of the destination directory
    Add jekyll-500px-embed to list of third-party plugins
    Simplified platform detection in Gemfile example for Windows
    Add the jekyll-jalali plugin added to the list of third-party plugins.
    Add Table of Contents to Troubleshooting page
    Add inline_highlight plugin to list of third-party plugins
    Add jekyll-mermaid plugin to list of third-party plugins

2.5.2 Changes

Minor Enhancements

    post_url should match post.name instead of slugs and dates (with backwards-compatibility)

Bug Fixes

    Fix bundle require for :jekyll_plugins
    Remove duplicate regexp phrase: ^\A
    Remove duplicate Conversion error: message in Convertible
    Print full conversion error message in Renderer#convert

Site Enhancements

    Change variable names in Google Analytics script
    Mention CSV files in the docs for data files
    Add trailing slash to paginate_path example.
    Get rid of noifniof (excerpt_separator)
    Sass improvements, around nesting mostly.
    Add webmentions.io plugin to the list of third-party plugins
    Add Sass mixins and use them.
    Slightly compress jekyll-sticker.jpg.
    Update gridism and separate out related but custom styles.
    Add remote-include plugin to list of third-party plugins

2.5.1 Changes

Bug Fixes

    Fix path sanitation bug related to Windows drive names (#3077)

Notes

Hot on the heels of v2.5.0, this release brings relief to our Windows users. It includes a fix for a 2.5.0 path sanitation change that has been confirmed to work on Windows.

To our Windows users: while we don’t officially support Windows, we don’t wish to impede your normal use of Jekyll at all. Our lack of full support for Windows is due to our lack of a Windows machine for development testing (no one on the core team has a Windows machine upon which to test new release candidates), not due to any malice or willful oversight. If you come to us with an issue, we are more than happy to work through it with you to come to a solution that works for all platforms. Along those lines, we have created a Windows Test Force (WTF) which is a group of Jekyll users dedicated to making sure all future releases work on Windows before they’re released so we don’t have this issue again. A special thanks goes out to the initial WTF team members, XhmikosR, Julian Thilo, Pedro Rogério, and Alfred Xing.

Happy Jekylling!

2.5.0 Changes

Minor Enhancements

    Require gems in :jekyll_plugins Gemfile group unless JEKYLL_NO_BUNDLER_REQUIRE is specified in the environment.
    Centralize path sanitation in the Site object
    Allow placeholders in permalinks
    Allow users to specify the log level via JEKYLL_LOG_LEVEL.
    Fancy Indexing with WEBrick
    Allow Enumerables to be used with where filter.
    Meta descriptions in the site template now use page.excerpt if it's available
    Change indentation in head.html of site template to 2 spaces from 4
    Use a $content-width variable instead of a fixed value in the site template CSS
    Strip newlines in site template <meta> description.
    Add link to atom feed in head of site template files
    Performance optimizations
    Use Hash#each_key instead of Hash#keys.each to speed up iteration over hash keys.
    Further minor performance enhancements.
    Add 'b' and 's' aliases for build and serve, respectively

Bug Fixes

    Fix Rouge's RedCarpet plugin interface integration
    Remove --watch from the site template blog post since it defaults to watching in in 2.4.0
    Fix code for media query mixin in site template
    Allow post URL's to have .htm extensions
    Utils.slugify: Don't create new objects when gsubbing
    The jsonify filter should deep-convert to Liquid when given an Array.
    Apply jsonify filter to Hashes deeply and effectively
    Use 127.0.0.1 as default host instead of 0.0.0.0
    In the case that a Gemfile does not exist, ensure Jekyll doesn't fail on requiring the Gemfile group

Development Fixes

    Fix a typo in the doc block for Jekyll::URL.escape_path
    Add integration test for jekyll new --blank in TestUnit
    Add unit test for jekyll new --force logic
    Update outdated comment for Convertible#transform
    Add Hakiri badge to README.
    Add some simple benchmarking tools.

Site Enhancements

    NOKOGIRI_USE_SYSTEM_LIBRARIES=true decreases installation time.
    Add FormKeep to resources as Jekyll form backend
    Fixing a mistake in the name of the new Liquid tag
    Update Font Awesome to v4.2.0.
    Fix link to #2895 in 2.4.0 release post.
    Add Big Footnotes for Kramdown plugin to list of third-party plugins
    Remove warning regarding GHP use of singular types for front matter defaults
    Fix quote character typo in site documentation for templates
    Point Liquid links to Liquid’s Github wiki
    Add HTTP Basic Auth (.htaccess) plugin to list of third-party plugins
    (Minor) Grammar & _config.yml filename fixes
    Added mathml.rb to the list of third-party plugins.
    Add --force_polling to the list of configuration options
    Escape unicode characters in site CSS
    Add note about using the github-pages gem via pages.github.com/versions.json
    Update usage documentation to reflect 2.4 auto-enabling of --watch.
    Add --skip-initial-build to configuration docs
    Fix a minor typo in Templates docs page
    Add a ditaa-ditaa plugin under Other section on the Plugins page
    Add build/serve -V option to configuration documentation
    Add 'Jekyll Twitter Plugin' to list of third-party plugins
    Docs: Update normalize.css to v3.0.2.
    Fix typo in Continuous Integration documentation
    Clarify behavior of :categories in permalinks
