### PR TITLE
Bumping pygments to 2.0.2

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -22,7 +22,7 @@ class GitHubPages
       "liquid"                => "2.6.2",
 
       # Highlighters
-      "pygments.rb"           => "0.6.3",
+      "pygments.rb"           => "2.0.2",
 
       # Plugins
       "jemoji"                => "0.4.0",


### PR DESCRIPTION
Bumping to latest version of pygments to add support for Swift syntax highlighting, which is only available in pygments > 2.0