### PR TITLE
Return the proper exit code from the DNS Check

### DIFF
--- a/bin/github-pages
+++ b/bin/github-pages
@@ -47,8 +47,10 @@ Mercenary.program(:"github-pages") do |p|
       puts "Checking domain #{cname}..."
       if check.valid?
         puts "Everything looks a-okay! :)"
+        exit 0
       else
         puts "Uh oh. Looks like something's fishy: #{check.reason}"
+        exit 1
       end
     end
   end


### PR DESCRIPTION
This would allow users to call `github-pages health-check` as part of CI and receive the proper exit code.