### PR TITLE
Update Jekyll Sitemap to 0.9.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -28,7 +28,7 @@ class GitHubPages
       "jemoji"                => "0.5.0",
       "jekyll-mentions"       => "0.2.1",
       "jekyll-redirect-from"  => "0.8.0",
-      "jekyll-sitemap"        => "0.8.1",
+      "jekyll-sitemap"        => "0.9.0",
       "jekyll-feed"           => "0.3.1",
     }
   end


### PR DESCRIPTION
Update Jekyll Sitemap to 0.9.0. [Only changes](https://github.com/jekyll/jekyll-sitemap/compare/v0.8.1...v0.9.0) are added tests and Jekyll 3.x support, neither of which should affect Pages.