### PR TITLE
Fix deprecation warning of rspec

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require File.expand_path("../../lib/github-pages.rb", __FILE__)
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values=
is now set to true as default