### PR TITLE
Jekyll 3.0.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem 'jemoji', github: "jekyll/jemoji", branch: "html-pipeline-2-2"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem 'jekyll-mentions', github: "jekyll/jekyll-mentions", branch: "jekyll-3"
+gem 'jemoji', github: "jekyll/jemoji", branch: "html-pipeline-2-2"

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,4 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'jekyll-mentions', github: "jekyll/jekyll-mentions", branch: "jekyll-3"
 gem 'jemoji', github: "jekyll/jemoji", branch: "html-pipeline-2-2"

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -7,7 +7,7 @@ class GitHubPages
   def self.gems
     {
       # Jekyll
-      "jekyll"                => "3.0.0",
+      "jekyll"                => "3.0.1",
       "jekyll-sass-converter" => "1.3.0",
 
       # Converters

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -17,10 +17,11 @@ class GitHubPages
       "redcarpet"                 => "3.3.3",
       "RedCloth"                  => "4.2.9",
 
-      # Misc
+      # Liquid
       "liquid"                    => "3.0.6",
+
+      # Highlighters
       "rouge"                     => "1.10.1",
-      "toml"                      => "0.1.2"
 
       # Plugins
       "jemoji"                    => "0.5.1",

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -26,7 +26,7 @@ class GitHubPages
       # Plugins
       "jemoji"                => "0.5.0",
       "jekyll-mentions"       => "0.2.1",
-      "jekyll-redirect-from"  => "0.8.0",
+      "jekyll-redirect-from"  => "0.9.0",
       "jekyll-sitemap"        => "0.9.0",
       "jekyll-feed"           => "0.3.1",
     }

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -21,7 +21,7 @@ class GitHubPages
       "liquid"                => "3.0.6",
 
       # Highlighters
-      "pygments.rb"           => "0.6.3",
+      "rouge"                 => "1.10.1",
 
       # Plugins
       "jemoji"                => "0.5.0",

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -17,7 +17,7 @@ class GitHubPages
       "RedCloth"                  => "4.2.9",
 
       # Liquid
-      "liquid"                    => "2.6.2",
+      "liquid"                    => "3.0.6",
 
       # Highlighters
       "rouge"                     => "1.10.1",

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -7,7 +7,7 @@ class GitHubPages
   def self.gems
     {
       # Jekyll
-      "jekyll"                    => "2.4.0",
+      "jekyll"                    => "3.0.1",
       "jekyll-sass-converter"     => "1.3.0",
 
       # Converters

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -17,11 +17,10 @@ class GitHubPages
       "redcarpet"                 => "3.3.3",
       "RedCloth"                  => "4.2.9",
 
-      # Liquid
+      # Misc
       "liquid"                    => "3.0.6",
-
-      # Highlighters
       "rouge"                     => "1.10.1",
+      "toml"                      => "0.1.2"
 
       # Plugins
       "jemoji"                    => "0.5.1",

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -7,7 +7,7 @@ class GitHubPages
   def self.gems
     {
       # Jekyll
-      "jekyll"                    => "3.0.1",
+      "jekyll"                    => "3.0.2",
       "jekyll-sass-converter"     => "1.3.0",
       "jekyll-textile-converter"  => "0.1.0",
 

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -9,6 +9,7 @@ class GitHubPages
       # Jekyll
       "jekyll"                    => "3.0.1",
       "jekyll-sass-converter"     => "1.3.0",
+      "jekyll-textile-converter"  => "0.1.0",
 
       # Converters
       "kramdown"                  => "1.9.0",

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -10,6 +10,7 @@ class GitHubPages
       "jekyll"                => "3.0.0",
       "jekyll-coffeescript"   => "1.0.1",
       "jekyll-sass-converter" => "1.3.0",
+      "jekyll-paginate"       => "1.1.0",
 
       # Converters
       "kramdown"              => "1.9.0",
@@ -24,7 +25,7 @@ class GitHubPages
       "rouge"                 => "1.10.1",
 
       # Plugins
-      "jemoji"                => "0.5.0",
+      "jemoji"                => "0.5.1",
       "jekyll-mentions"       => "1.0.0",
       "jekyll-redirect-from"  => "0.9.0",
       "jekyll-sitemap"        => "0.9.0",

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -30,6 +30,7 @@ class GitHubPages
       "jekyll-redirect-from"  => "0.9.0",
       "jekyll-sitemap"        => "0.9.0",
       "jekyll-feed"           => "0.3.1",
+      "jekyll-gist"           => "1.3.5"
     }
   end
 

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -7,7 +7,7 @@ class GitHubPages
   def self.gems
     {
       # Jekyll
-      "jekyll"                => "2.4.0",
+      "jekyll"                => "3.0.0",
       "jekyll-coffeescript"   => "1.0.1",
       "jekyll-sass-converter" => "1.3.0",
 
@@ -19,7 +19,7 @@ class GitHubPages
       "RedCloth"              => "4.2.9",
 
       # Liquid
-      "liquid"                => "2.6.2",
+      "liquid"                => "3.0.6",
 
       # Highlighters
       "pygments.rb"           => "0.6.3",

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -1,5 +1,5 @@
 class GitHubPages
-  VERSION = 39
+  VERSION = 40
 
   # Jekyll and related dependency versions as used by GitHub Pages.
   # For more information see:

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -13,7 +13,6 @@ class GitHubPages
 
       # Converters
       "kramdown"              => "1.9.0",
-      "maruku"                => "0.7.0",
       "rdiscount"             => "2.1.7",
       "redcarpet"             => "3.3.2",
       "RedCloth"              => "4.2.9",

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -25,7 +25,7 @@ class GitHubPages
 
       # Plugins
       "jemoji"                => "0.5.0",
-      "jekyll-mentions"       => "0.2.1",
+      "jekyll-mentions"       => "1.0.0",
       "jekyll-redirect-from"  => "0.9.0",
       "jekyll-sitemap"        => "0.9.0",
       "jekyll-feed"           => "0.3.1",

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -8,9 +8,7 @@ class GitHubPages
     {
       # Jekyll
       "jekyll"                => "3.0.0",
-      "jekyll-coffeescript"   => "1.0.1",
       "jekyll-sass-converter" => "1.3.0",
-      "jekyll-paginate"       => "1.1.0",
 
       # Converters
       "kramdown"              => "1.9.0",
@@ -30,7 +28,10 @@ class GitHubPages
       "jekyll-redirect-from"  => "0.9.0",
       "jekyll-sitemap"        => "0.9.0",
       "jekyll-feed"           => "0.3.1",
-      "jekyll-gist"           => "1.3.5"
+      "jekyll-gist"           => "1.3.5",
+      "jekyll-paginate"       => "1.1.0",
+      "jekyll-coffeescript"   => "1.0.1",
+
     }
   end
 

--- a/spec/github-pages_spec.rb
+++ b/spec/github-pages_spec.rb
@@ -15,7 +15,7 @@ describe(GitHubPages) do
     expect(described_class.versions).to include("github-pages")
   end
 
-  %w[jekyll kramdown liquid maruku rdiscount redcarpet RedCloth].each do |gem|
+  %w[jekyll kramdown liquid rouge rdiscount redcarpet RedCloth].each do |gem|
     it "exposes #{gem} dependency version" do
       expect(described_class.gems[gem]).to be_a(String)
       expect(described_class.gems[gem]).not_to be_empty


### PR DESCRIPTION
This is a progress tracking branch for getting things where the GitHub Pages Gem could be bumped to use Jekyll 3.0.x and related dependencies. 

Initial todo to establish a baseline of what's changed:

- [x] Get the Gemfile to bundle
- [x] Confirm plugins work on 3.x
  - [x] jemoji             
  - [x] jekyll-mentions 
  - [x] jekyll-redirect-from 
  - [x] jekyll-sitemap 
  - [x] jekyll-feed
- [x] Enumerate breaking changes

## Known breaking changes

* Dropped support for Ruby < 2.0
* Rouge is now the default highlighter
* Coffeescript and paginate must be explicitly included
* Dropped Maruku support

Please contribute only constructive comments below. If you would like to follow the effort's progress, you may click `subscribe` in the right-hand sidebar.