### PR TITLE
Add jekyll last modified at plugin

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -7,29 +7,29 @@ class GitHubPages
   def self.gems
     {
       # Jekyll
-      "jekyll"                => "2.4.0",
-      "jekyll-coffeescript"   => "1.0.1",
-      "jekyll-sass-converter" => "1.3.0",
+      "jekyll"                  => "2.4.0",
+      "jekyll-coffeescript"     => "1.0.1",
+      "jekyll-sass-converter"   => "1.3.0",
 
       # Converters
-      "kramdown"              => "1.5.0",
-      "maruku"                => "0.7.0",
-      "rdiscount"             => "2.1.7",
-      "redcarpet"             => "3.3.2",
-      "RedCloth"              => "4.2.9",
+      "kramdown"                => "1.5.0",
+      "maruku"                  => "0.7.0",
+      "rdiscount"               => "2.1.7",
+      "redcarpet"               => "3.3.2",
+      "RedCloth"                => "4.2.9",
 
       # Liquid
-      "liquid"                => "2.6.2",
+      "liquid"                  => "2.6.2",
 
       # Highlighters
-      "pygments.rb"           => "0.6.3",
+      "pygments.rb"             => "0.6.3",
 
       # Plugins
-      "jemoji"                => "0.5.0",
-      "jekyll-mentions"       => "0.2.1",
-      "jekyll-redirect-from"  => "0.8.0",
-      "jekyll-sitemap"        => "0.9.0",
-      "jekyll-feed"           => "0.3.1",
+      "jemoji"                  => "0.5.0",
+      "jekyll-mentions"         => "0.2.1",
+      "jekyll-redirect-from"    => "0.8.0",
+      "jekyll-sitemap"          => "0.9.0",
+      "jekyll-feed"             => "0.3.1",
     }
   end
 

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -26,6 +26,7 @@ class GitHubPages
 
       # Plugins
       "jemoji"                  => "0.5.0",
+      "jekyll-last-modified-at" => "0.3.4",
       "jekyll-mentions"         => "0.2.1",
       "jekyll-redirect-from"    => "0.8.0",
       "jekyll-sitemap"          => "0.9.0",


### PR DESCRIPTION
I really want to be able to use the jekyll-last-modified-at plugin, so that I don't have to maintain those dates by hand in my pages. This PR adds it as a dependency to the project, using its most recent version.

Note: the second commit on this branch is the business. The first one is just formatting.