### PR TITLE
Bump minor gem versions in preparation for Jekyll 3.0.x

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -31,6 +31,7 @@ class GitHubPages
       "jekyll-sitemap"            => "0.9.0",
       "jekyll-feed"               => "0.3.1",
       "jekyll-gist"               => "1.4.0",
+      "jekyll-paginate"           => "1.1.0",
       "github-pages-health-check" => "0.5.3",
     }
   end

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -12,10 +12,10 @@ class GitHubPages
       "jekyll-sass-converter"     => "1.3.0",
 
       # Converters
-      "kramdown"                  => "1.5.0",
+      "kramdown"                  => "1.9.0",
       "maruku"                    => "0.7.0",
-      "rdiscount"                 => "2.1.7",
-      "redcarpet"                 => "3.3.2",
+      "rdiscount"                 => "2.1.8",
+      "redcarpet"                 => "3.3.3",
       "RedCloth"                  => "4.2.9",
 
       # Liquid
@@ -30,6 +30,7 @@ class GitHubPages
       "jekyll-redirect-from"      => "0.8.0",
       "jekyll-sitemap"            => "0.9.0",
       "jekyll-feed"               => "0.3.1",
+      "jekyll-gist"               => "1.4.0",
       "github-pages-health-check" => "0.5.3",
     }
   end


### PR DESCRIPTION
This pull request upgrades gems where there's a minor gem bump, in order to minimize the diff and number of moving parts in https://github.com/github/pages-gem/pulls.