### PR TITLE
Bump jekyll-redirect-from from v0.8.0 to v0.9.1

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -27,7 +27,7 @@ class GitHubPages
       # Plugins
       "jemoji"                    => "0.5.0",
       "jekyll-mentions"           => "0.2.1",
-      "jekyll-redirect-from"      => "0.8.0",
+      "jekyll-redirect-from"      => "0.9.1",
       "jekyll-sitemap"            => "0.9.0",
       "jekyll-feed"               => "0.3.1",
       "jekyll-gist"               => "1.4.0",


### PR DESCRIPTION
Diff: https://github.com/jekyll/jekyll-redirect-from/compare/v0.8.0...v0.9.1
v0.9.0: https://github.com/jekyll/jekyll-redirect-from/releases/tag/v0.9.0
v0.9.1: https://github.com/jekyll/jekyll-redirect-from/releases/tag/v0.9.1

All changes made in v0.9.0 were to support Jekyll 3.
v0.9.1 had one change to ensure site.github values are stringified
and changed the default template to use double quotes instead of single quotes.

Created per https://github.com/github/pages-gem/pull/175#discussion_r49207272