### PR TITLE
Bump pages health check 0.6.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -32,7 +32,7 @@ class GitHubPages
       "jekyll-feed"               => "0.3.1",
       "jekyll-gist"               => "1.4.0",
       "jekyll-paginate"           => "1.1.0",
-      "github-pages-health-check" => "0.5.3",
+      "github-pages-health-check" => "0.6.0",
       "jekyll-seo-tag"            => "0.1.4",
     }
   end


### PR DESCRIPTION
See https://github.com/github/pages-health-check/releases/tag/v0.6.0.