### PR TITLE
Bump jekyll-sitemap from v0.9 to v0.10

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -28,7 +28,7 @@ class GitHubPages
       "jemoji"                    => "0.5.0",
       "jekyll-mentions"           => "0.2.1",
       "jekyll-redirect-from"      => "0.9.1",
-      "jekyll-sitemap"            => "0.9.0",
+      "jekyll-sitemap"            => "0.10.0",
       "jekyll-feed"               => "0.3.1",
       "jekyll-gist"               => "1.4.0",
       "jekyll-paginate"           => "1.1.0",


### PR DESCRIPTION
Release: https://github.com/jekyll/jekyll-sitemap/releases/tag/v0.10.0
Diff: https://github.com/jekyll/jekyll-sitemap/compare/v0.9.0...v0.10.0

Let's hold on this until #175 is merged, maybe?

/cc @github/pages