### PR TITLE
Upgrade to Jekyll v3.0.3

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -7,7 +7,7 @@ class GitHubPages
   def self.gems
     {
       # Jekyll
-      "jekyll"                    => "3.0.2",
+      "jekyll"                    => "3.0.3",
       "jekyll-sass-converter"     => "1.3.0",
       "jekyll-textile-converter"  => "0.1.0",
 


### PR DESCRIPTION
Release: https://github.com/jekyll/jekyll/releases/tag/v3.0.3
Diff: https://github.com/jekyll/jekyll/compare/v3.0.2...v3.0.3