### PR TITLE
Bump pages health check to 0.6.1

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -1,5 +1,5 @@
 class GitHubPages
-  VERSION = 47
+  VERSION = 48
 
   # Jekyll and related dependency versions as used by GitHub Pages.
   # For more information see:
@@ -31,7 +31,7 @@ class GitHubPages
       "jekyll-feed"               => "0.3.1",
       "jekyll-gist"               => "1.4.0",
       "jekyll-paginate"           => "1.1.0",
-      "github-pages-health-check" => "0.6.0",
+      "github-pages-health-check" => "0.6.1",
       "jekyll-coffeescript"       => "1.0.1",
       "jekyll-seo-tag"            => "1.0.0",
     }

--- a/script/cibuild
+++ b/script/cibuild
@@ -5,5 +5,7 @@ set -ex
 
 bundle exec jekyll --version
 bundle exec rspec
+
+rm -Rf ./test-site
 bundle exec jekyll new test-site
 cd test-site && bundle exec jekyll build --trace

--- a/script/release
+++ b/script/release
@@ -18,7 +18,8 @@ gem build -q github-pages.gemspec
 
 # Make sure we're on the master branch.
 
-(git branch | grep -q '* master') || {
+(git branch | grep -q '
+master') || {
   echo "Only release from the master branch."
   exit 1
 }

--- a/script/release
+++ b/script/release
@@ -18,8 +18,7 @@ gem build -q github-pages.gemspec
 
 # Make sure we're on the master branch.
 
-(git branch | grep -q '
-master') || {
+(git branch | grep -q 'master') || {
   echo "Only release from the master branch."
   exit 1
 }


### PR DESCRIPTION
[Release](https://github.com/github/pages-health-check/releases/tag/v0.6.1)

Nothing too exciting, but the CloudFlare IPs need to be bumped to get tests passing upstream.

