### PR TITLE
Bump Jekyll mentions to 1.0.1

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -25,7 +25,7 @@ class GitHubPages
 
       # Plugins
       "jemoji"                    => "0.5.1",
-      "jekyll-mentions"           => "1.0.0",
+      "jekyll-mentions"           => "1.0.1",
       "jekyll-redirect-from"      => "0.9.1",
       "jekyll-sitemap"            => "0.10.0",
       "jekyll-feed"               => "0.3.1",


### PR DESCRIPTION
Which simply solves for double @mentions in Jekyll > 3.0.0. See https://github.com/jekyll/jekyll-mentions/releases/tag/v1.0.1