### PR TITLE
Bump github pages health check to 1.0.1

### DIFF
--- a/bin/github-pages
+++ b/bin/github-pages
@@ -45,7 +45,7 @@ Mercenary.program(:"github-pages") do |p|
       cname_path = File.expand_path "CNAME", Dir.pwd
       raise "No CNAME file found in current directory" unless File.exists?(cname_path)
       cname = File.open(cname_path).read.strip
-      check = GitHubPages::HealthCheck.new(cname)
+      check = GitHubPages::HealthCheck.check(cname)
       puts "Checking domain #{cname}..."
       if check.valid?
         puts "Everything looks a-okay! :)"

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -1,4 +1,4 @@
-class GitHubPages
+module GitHubPages
   VERSION = 48
 
   # Jekyll and related dependency versions as used by GitHub Pages.

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -31,7 +31,7 @@ class GitHubPages
       "jekyll-feed"               => "0.3.1",
       "jekyll-gist"               => "1.4.0",
       "jekyll-paginate"           => "1.1.0",
-      "github-pages-health-check" => "0.6.1",
+      "github-pages-health-check" => "1.0.1",
       "jekyll-coffeescript"       => "1.0.1",
       "jekyll-seo-tag"            => "1.0.0",
     }


### PR DESCRIPTION
For the most part, the big change is the expansion of the invalid CNAME checks to include checks for CNAMEs to `pages.github.com` and directly to Fastly. See https://github.com/github/pages-health-check/releases/tag/v1.0.0. 