### PR TITLE
Bump jekyll-feed to 0.4.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -28,7 +28,7 @@ module GitHubPages
       "jekyll-mentions"           => "1.0.1",
       "jekyll-redirect-from"      => "0.9.1",
       "jekyll-sitemap"            => "0.10.0",
-      "jekyll-feed"               => "0.3.1",
+      "jekyll-feed"               => "0.4.0",
       "jekyll-gist"               => "1.4.0",
       "jekyll-paginate"           => "1.1.0",
       "github-pages-health-check" => "1.0.1",


### PR DESCRIPTION
https://github.com/jekyll/jekyll-feed/releases/tag/v0.4.0:

  * Feed uses `site.title`, or `site.name` if `title` doesn't exist 
  * Replace newlines with spaces in `title` and `summary` elements 
  * Properly render post content with Jekyll 