### PR TITLE
Bump Jekyll SEO Tag to 1.2.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -33,7 +33,7 @@ module GitHubPages
       "jekyll-paginate"           => "1.1.0",
       "github-pages-health-check" => "1.0.1",
       "jekyll-coffeescript"       => "1.0.1",
-      "jekyll-seo-tag"            => "1.0.0",
+      "jekyll-seo-tag"            => "1.2.0",
     }
   end
 


### PR DESCRIPTION
* [v1.1.0](https://github.com/benbalter/jekyll-seo-tag/releases/tag/v1.1.0)
* [v1.2.0](https://github.com/benbalter/jekyll-seo-tag/releases/tag/v1.2.0)

Specifically, template changes to:

* Add support for Facebook App metadata
* Add support for verifying site's with Google webmaster tools
* Support for global author data 
* Ability to disable `<title>` tag 
* Output the plugin version