### PR TITLE
Bump Jekyll SEO Tag to v1.3.0

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -33,7 +33,7 @@ module GitHubPages
       "jekyll-paginate"           => "1.1.0",
       "github-pages-health-check" => "1.0.1",
       "jekyll-coffeescript"       => "1.0.1",
-      "jekyll-seo-tag"            => "1.3.0",
+      "jekyll-seo-tag"            => "1.3.1",
     }
   end
 

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -1,5 +1,5 @@
 module GitHubPages
-  VERSION = 51
+  VERSION = 52
 
   # Jekyll and related dependency versions as used by GitHub Pages.
   # For more information see:
@@ -33,7 +33,7 @@ module GitHubPages
       "jekyll-paginate"           => "1.1.0",
       "github-pages-health-check" => "1.0.1",
       "jekyll-coffeescript"       => "1.0.1",
-      "jekyll-seo-tag"            => "1.2.0",
+      "jekyll-seo-tag"            => "1.3.0",
     }
   end
 


### PR DESCRIPTION
[Release notes](https://github.com/jekyll/jekyll-seo-tag/releases/tag/v1.3.0)