### PR TITLE
Bump jemoji to v0.6.1

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -24,7 +24,7 @@ module GitHubPages
       "rouge"                     => "1.10.1",
 
       # Plugins
-      "jemoji"                    => "0.5.1",
+      "jemoji"                    => "0.6.0",
       "jekyll-mentions"           => "1.0.1",
       "jekyll-redirect-from"      => "0.9.1",
       "jekyll-sitemap"            => "0.10.0",

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -24,7 +24,7 @@ module GitHubPages
       "rouge"                     => "1.10.1",
 
       # Plugins
-      "jemoji"                    => "0.6.0",
+      "jemoji"                    => "0.6.1",
       "jekyll-mentions"           => "1.0.1",
       "jekyll-redirect-from"      => "0.9.1",
       "jekyll-sitemap"            => "0.10.0",


### PR DESCRIPTION
**Release**: https://github.com/jekyll/jemoji/releases/tag/v0.6.0
**Diff**: https://github.com/jekyll/jemoji/compare/v0.5.1...v0.6.0

Replaces #233 due to a bug.