### PR TITLE
Add script/fmt & tell script/cibuild to use it

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -5,7 +5,7 @@ set -ex
 
 bundle exec jekyll --version
 bundle exec rspec
-bundle exec rubocop -D -S
+script/fmt --display-style-guide
 
 rm -Rf ./test-site
 bundle exec jekyll new test-site

--- a/script/fmt
+++ b/script/fmt
@@ -1,0 +1,2 @@
+#!/bin/sh
+bundle exec rubocop -D $@


### PR DESCRIPTION
Makes it easier to run `rubocop -a` to autocorrect offenses without having to worry about bundler.

:smile: