### PR TITLE
Add dependency-configuration sanity checks

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -15,11 +15,10 @@ module GitHubPages
       "redcarpet"                 => "3.3.3",
       "RedCloth"                  => "4.2.9",
 
-      # Liquid
+      # Misc
       "liquid"                    => "3.0.6",
-
-      # Highlighters
       "rouge"                     => "1.10.1",
+      "github-pages-health-check" => "1.1.0",
 
       # Plugins
       "jemoji"                    => "0.5.1",
@@ -29,7 +28,6 @@ module GitHubPages
       "jekyll-feed"               => "0.4.0",
       "jekyll-gist"               => "1.4.0",
       "jekyll-paginate"           => "1.1.0",
-      "github-pages-health-check" => "1.1.0",
       "jekyll-coffeescript"       => "1.0.1",
       "jekyll-seo-tag"            => "1.3.2",
       "jekyll-github-metadata"    => "1.9.0"

--- a/spec/github-pages-configuration_spec.rb
+++ b/spec/github-pages-configuration_spec.rb
@@ -77,4 +77,22 @@ describe(GitHubPages::Configuration) do
       expect(site.config["testing"]).to eql("123")
     end
   end
+
+  context "plugins" do
+    context "whitelists all default plugins" do
+      GitHubPages::Configuration::DEFAULT_PLUGINS.each do |plugin|
+        it "whitelists the #{plugin} plugin" do
+          expect(GitHubPages::Configuration::PLUGIN_WHITELIST).to include(plugin)
+        end
+      end
+    end
+
+    context "versions all whitelisted plugins" do
+      GitHubPages::Configuration::PLUGIN_WHITELIST.each do |plugin|
+        it "versions the #{plugin} plugin" do
+          expect(GitHubPages::Dependencies::VERSIONS.keys).to include(plugin)
+        end
+      end
+    end
+  end
 end

--- a/spec/github-pages-dependencies_spec.rb
+++ b/spec/github-pages-dependencies_spec.rb
@@ -1,6 +1,12 @@
 require "spec_helper"
 
 describe(GitHubPages::Dependencies) do
+  CORE_DEPENDENCIES = %w(
+    jekyll kramdown liquid rouge rdiscount redcarpet RedCloth
+    jekyll-sass-converter github-pages-health-check
+  ).freeze
+  PLUGINS = described_class::VERSIONS.keys - CORE_DEPENDENCIES
+
   it "exposes its gem versions" do
     expect(described_class.gems).to be_a(Hash)
   end
@@ -11,10 +17,20 @@ describe(GitHubPages::Dependencies) do
     expect(described_class.versions).to include("github-pages")
   end
 
-  %w(jekyll kramdown liquid rouge rdiscount redcarpet RedCloth).each do |gem|
-    it "exposes #{gem} dependency version" do
-      expect(described_class.gems[gem]).to be_a(String)
-      expect(described_class.gems[gem]).not_to be_empty
+  context "jekyll core dependencies" do
+    CORE_DEPENDENCIES.each do |gem|
+      it "exposes #{gem} dependency version" do
+        expect(described_class.gems[gem]).to be_a(String)
+        expect(described_class.gems[gem]).not_to be_empty
+      end
+    end
+  end
+
+  context "plugins" do
+    PLUGINS.each do |plugin|
+      it "whitelists the #{plugin} plugin" do
+        expect(GitHubPages::Configuration::PLUGIN_WHITELIST).to include(plugin)
+      end
     end
   end
 


### PR DESCRIPTION
Now that we're versioning the config this PR adds a few minor sanity checks to ensure that:

* All default plugins are whitelisted
* All versioned plugins are whitelisted
* All whitelisted plugins are versioned
