### PR TITLE
Fix spelling of syntax_highlighter

### DIFF
--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -58,9 +58,9 @@ module GitHubPages
       "whitelist"   => PLUGIN_WHITELIST,
       "highlighter" => "rouge",
       "kramdown"    => {
-        "template"          => "",
-        "math_engine"       => "mathjax",
-        "syntax_highligher" => "rouge"
+        "template"           => "",
+        "math_engine"        => "mathjax",
+        "syntax_highlighter" => "rouge"
       },
       "gist"        => {
         "noscript"  => false


### PR DESCRIPTION
Because setting the `syntax_highligher` property won't do too much to affect Kramdown's syntax highlighter.