### PR TITLE
[May 1st] Remove non-kramdown markup interpreters 

### DIFF
--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -7,7 +7,6 @@ module GitHubPages
       jekyll-gist
       jekyll-github-metadata
       jekyll-paginate
-      jekyll-textile-converter
     ).freeze
 
     # Plugins allowed by GitHub Pages

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -11,9 +11,6 @@ module GitHubPages
 
       # Converters
       "kramdown"                  => "1.10.0",
-      "rdiscount"                 => "2.1.8",
-      "redcarpet"                 => "3.3.3",
-      "RedCloth"                  => "4.2.9",
 
       # Misc
       "liquid"                    => "3.0.6",

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -7,7 +7,6 @@ module GitHubPages
       # Jekyll
       "jekyll"                    => "3.0.3",
       "jekyll-sass-converter"     => "1.3.0",
-      "jekyll-textile-converter"  => "0.1.0",
 
       # Converters
       "kramdown"                  => "1.10.0",

--- a/lib/github-pages/version.rb
+++ b/lib/github-pages/version.rb
@@ -1,3 +1,3 @@
 module GitHubPages
-  VERSION = 67
+  VERSION = 68
 end

--- a/spec/github-pages-dependencies_spec.rb
+++ b/spec/github-pages-dependencies_spec.rb
@@ -2,8 +2,7 @@ require "spec_helper"
 
 describe(GitHubPages::Dependencies) do
   CORE_DEPENDENCIES = %w(
-    jekyll kramdown liquid rouge rdiscount redcarpet RedCloth
-    jekyll-sass-converter github-pages-health-check
+    jekyll kramdown liquid rouge jekyll-sass-converter github-pages-health-check
   ).freeze
   PLUGINS = described_class::VERSIONS.keys - CORE_DEPENDENCIES
 

--- a/spec/github-pages-dependencies_spec.rb
+++ b/spec/github-pages-dependencies_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe(GitHubPages::Dependencies) do
   CORE_DEPENDENCIES = %w(
-    jekyll kramdown liquid rouge jekyll-sass-converter 
+    jekyll kramdown liquid rouge jekyll-sass-converter
     github-pages-health-check listen
   ).freeze
   PLUGINS = described_class::VERSIONS.keys - CORE_DEPENDENCIES


### PR DESCRIPTION
This pull request removes the three non-Kramdown Markdown interpreters in anticipation of the May 1st sunset.

See https://github.com/github/pages-gem/issues/179 and https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0 for context