### PR TITLE
Backwards-compatibilize user configuration

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -12,8 +12,6 @@ module GitHubPages
   end
 end
 
-Jekyll.logger.debug "GitHub Pages:", "github-pages v#{GitHubPages::VERSION}"
-Jekyll.logger.debug "GitHub Pages:", "jekyll v#{Jekyll::VERSION}"
 Jekyll::Hooks.register :site, :after_reset do |site|
   GitHubPages::Configuration.set(site)
 end

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -54,7 +54,7 @@ module GitHubPages
     OVERRIDES = {
       "lsi"         => false,
       "safe"        => true,
-      "plugins"     => SecureRandom.hex,
+      "plugins_dir" => SecureRandom.hex,
       "whitelist"   => PLUGIN_WHITELIST,
       "highlighter" => "rouge",
       "kramdown"    => {
@@ -98,10 +98,11 @@ module GitHubPages
         # Merge user config into defaults
         config = Jekyll::Utils.deep_merge_hashes(MERGED_DEFAULTS, user_config)
           .fix_common_issues
+          .backwards_compatibilize
           .add_default_collections
 
-        # Merge overwrites into user config
-        config = Jekyll::Utils.deep_merge_hashes config, OVERRIDES
+        # Merge overwrites into user config & ensure fully compatible
+        config = Jekyll::Utils.deep_merge_hashes(config, OVERRIDES)
 
         # Ensure we have those gems we want.
         config["gems"] = Array(config["gems"]) | DEFAULT_PLUGINS

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -116,8 +116,14 @@ module GitHubPages
       # guards against double-processing via the value in #processed.
       def set(site)
         return if processed? site
+        print_debug_versions
         set!(site)
         processed(site)
+      end
+
+      def print_debug_versions
+        Jekyll.logger.debug "GitHub Pages:", "github-pages v#{GitHubPages::VERSION}"
+        Jekyll.logger.debug "GitHub Pages:", "jekyll v#{Jekyll::VERSION}"
       end
 
       # Set the site's configuration with all the proper defaults and overrides.

--- a/spec/github-pages-configuration_spec.rb
+++ b/spec/github-pages-configuration_spec.rb
@@ -1,11 +1,13 @@
 require "spec_helper"
 
 describe(GitHubPages::Configuration) do
+  let(:plugins_dir) { "_pluginz/are/fun" }
   let(:test_config) do
     {
       "source" => fixture_dir,
       "quiet" => true,
       "testing" => "123",
+      "plugins" => plugins_dir,
       "destination" => tmp_dir }
   end
   let(:configuration) { Jekyll.configuration(test_config) }
@@ -48,6 +50,12 @@ describe(GitHubPages::Configuration) do
     it "accepts local configs" do
       expect(effective_config["testing"]).to eql("123")
     end
+
+    it "backwards-compatibilizes" do
+      expect(effective_config["plugins"]).to be nil
+      expect(effective_config["plugins_dir"]).not_to eql(plugins_dir)
+      expect(effective_config["plugins_dir"]).to match(/[a-f0-9]{32}/)
+    end
   end
 
   context "#set being called via the hook" do
@@ -83,6 +91,12 @@ describe(GitHubPages::Configuration) do
 
     it "accepts local configs" do
       expect(site.config["testing"]).to eql("123")
+    end
+
+    it "backwards-compatibilizes" do
+      expect(effective_config["plugins"]).to be nil
+      expect(effective_config["plugins_dir"]).not_to eql(plugins_dir)
+      expect(effective_config["plugins_dir"]).to match(/[a-f0-9]{32}/)
     end
   end
 


### PR DESCRIPTION
Previous to this PR, you wouldn't be able to use `plugins`, `layouts` or any of the other deprecated options. They worked locally because Jekyll uses `Jekyll.configuration` to load the user's configuration, but once you tried on GitHub Pages, it would break because it's not using this same method.

/cc @github/pages 