### PR TITLE
Pin to Listen 3.0.6

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -30,7 +30,11 @@ module GitHubPages
       "jekyll-paginate"           => "1.1.0",
       "jekyll-coffeescript"       => "1.0.1",
       "jekyll-seo-tag"            => "1.3.3",
-      "jekyll-github-metadata"    => "1.11.0"
+      "jekyll-github-metadata"    => "1.11.0",
+
+      # Pin listen because it's broken on 2.1 & that's what we recommend.
+      # https://github.com/guard/listen/pull/371
+      "listen"                    => "3.0.6"
     }.freeze
 
     # Jekyll and related dependency versions as used by GitHub Pages.

--- a/spec/github-pages-dependencies_spec.rb
+++ b/spec/github-pages-dependencies_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe(GitHubPages::Dependencies) do
   CORE_DEPENDENCIES = %w(
     jekyll kramdown liquid rouge rdiscount redcarpet RedCloth
-    jekyll-sass-converter github-pages-health-check
+    jekyll-sass-converter github-pages-health-check listen
   ).freeze
   PLUGINS = described_class::VERSIONS.keys - CORE_DEPENDENCIES
 


### PR DESCRIPTION
Listen 3.1 and up now requires Ruby 2.2. This PR pins it to 3.0.6 because we run and recommend users use v2.1.7.

Relevant PR: https://github.com/guard/listen/pull/371

/cc @github/pages @mlinksva