### PR TITLE
Revert "Backwards-compatibilize user configuration"

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -12,6 +12,8 @@ module GitHubPages
   end
 end
 
+Jekyll.logger.debug "GitHub Pages:", "github-pages v#{GitHubPages::VERSION}"
+Jekyll.logger.debug "GitHub Pages:", "jekyll v#{Jekyll::VERSION}"
 Jekyll::Hooks.register :site, :after_reset do |site|
   GitHubPages::Configuration.set(site)
 end

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -12,8 +12,6 @@ module GitHubPages
   end
 end
 
-Jekyll.logger.debug "GitHub Pages:", "github-pages v#{GitHubPages::VERSION}"
-Jekyll.logger.debug "GitHub Pages:", "jekyll v#{Jekyll::VERSION}"
 Jekyll::Hooks.register :site, :after_reset do |site|
   GitHubPages::Configuration.set(site)
 end

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -116,8 +116,16 @@ module GitHubPages
       # guards against double-processing via the value in #processed.
       def set(site)
         return if processed? site
+        debug_print_versions
         set!(site)
         processed(site)
+      end
+
+      # Print the versions for github-pages and jekyll to the debug
+      # stream for debugging purposes. See by running Jekyll with '--verbose'
+      def debug_print_versions
+        Jekyll.logger.debug "GitHub Pages:", "github-pages v#{GitHubPages::VERSION}"
+        Jekyll.logger.debug "GitHub Pages:", "jekyll v#{Jekyll::VERSION}"
       end
 
       # Set the site's configuration with all the proper defaults and overrides.

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -54,7 +54,7 @@ module GitHubPages
     OVERRIDES = {
       "lsi"         => false,
       "safe"        => true,
-      "plugins_dir" => SecureRandom.hex,
+      "plugins"     => SecureRandom.hex,
       "whitelist"   => PLUGIN_WHITELIST,
       "highlighter" => "rouge",
       "kramdown"    => {
@@ -98,11 +98,10 @@ module GitHubPages
         # Merge user config into defaults
         config = Jekyll::Utils.deep_merge_hashes(MERGED_DEFAULTS, user_config)
           .fix_common_issues
-          .backwards_compatibilize
           .add_default_collections
 
-        # Merge overwrites into user config & ensure fully compatible
-        config = Jekyll::Utils.deep_merge_hashes(config, OVERRIDES)
+        # Merge overwrites into user config
+        config = Jekyll::Utils.deep_merge_hashes config, OVERRIDES
 
         # Ensure we have those gems we want.
         config["gems"] = Array(config["gems"]) | DEFAULT_PLUGINS
@@ -116,14 +115,8 @@ module GitHubPages
       # guards against double-processing via the value in #processed.
       def set(site)
         return if processed? site
-        print_debug_versions
         set!(site)
         processed(site)
-      end
-
-      def print_debug_versions
-        Jekyll.logger.debug "GitHub Pages:", "github-pages v#{GitHubPages::VERSION}"
-        Jekyll.logger.debug "GitHub Pages:", "jekyll v#{Jekyll::VERSION}"
       end
 
       # Set the site's configuration with all the proper defaults and overrides.

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -55,6 +55,7 @@ module GitHubPages
       "lsi"         => false,
       "safe"        => true,
       "plugins"     => SecureRandom.hex,
+      "plugins_dir" => SecureRandom.hex,
       "whitelist"   => PLUGIN_WHITELIST,
       "highlighter" => "rouge",
       "kramdown"    => {

--- a/spec/github-pages-configuration_spec.rb
+++ b/spec/github-pages-configuration_spec.rb
@@ -1,13 +1,11 @@
 require "spec_helper"
 
 describe(GitHubPages::Configuration) do
-  let(:plugins_dir) { "_pluginz/are/fun" }
   let(:test_config) do
     {
       "source" => fixture_dir,
       "quiet" => true,
       "testing" => "123",
-      "plugins" => plugins_dir,
       "destination" => tmp_dir }
   end
   let(:configuration) { Jekyll.configuration(test_config) }
@@ -50,12 +48,6 @@ describe(GitHubPages::Configuration) do
     it "accepts local configs" do
       expect(effective_config["testing"]).to eql("123")
     end
-
-    it "backwards-compatibilizes" do
-      expect(effective_config["plugins"]).to be nil
-      expect(effective_config["plugins_dir"]).not_to eql(plugins_dir)
-      expect(effective_config["plugins_dir"]).to match(/[a-f0-9]{32}/)
-    end
   end
 
   context "#set being called via the hook" do
@@ -91,12 +83,6 @@ describe(GitHubPages::Configuration) do
 
     it "accepts local configs" do
       expect(site.config["testing"]).to eql("123")
-    end
-
-    it "backwards-compatibilizes" do
-      expect(effective_config["plugins"]).to be nil
-      expect(effective_config["plugins_dir"]).not_to eql(plugins_dir)
-      expect(effective_config["plugins_dir"]).to match(/[a-f0-9]{32}/)
     end
   end
 


### PR DESCRIPTION
Reverts github/pages-gem#276

Fixes https://github.com/github/pages-gem/issues/280  https://github.com/jekyll/jekyll/issues/4823 https://github.com/jekyll/jekyll/issues/4821