### PR TITLE
Require securerandom so we can call SecureRandom.hex

### DIFF
--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 module GitHubPages
   #
   class Configuration

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -1,4 +1,4 @@
-require 'securerandom'
+require "securerandom"
 
 module GitHubPages
   #


### PR DESCRIPTION
Fixes #278 
