### PR TITLE
Set 'future: true' for all GitHub Pages builds by default.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.2
   - 2.3.0
 
+before_install: gem install bundler # update bundler.
 script: "script/cibuild"
 env:
   global:

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -29,6 +29,7 @@ module GitHubPages
     DEFAULTS = {
       "jailed"   => false,
       "gems"     => DEFAULT_PLUGINS,
+      "future"   => true,
       "kramdown" => {
         "input"     => "GFM",
         "hard_wrap" => false

--- a/spec/github-pages-configuration_spec.rb
+++ b/spec/github-pages-configuration_spec.rb
@@ -18,6 +18,7 @@ describe(GitHubPages::Configuration) do
   context "#effective_config" do
     it "sets configuration defaults" do
       expect(effective_config["kramdown"]["input"]).to eql("GFM")
+      expect(effective_config["future"]).to eql(false)
     end
 
     it "sets default gems" do
@@ -52,6 +53,16 @@ describe(GitHubPages::Configuration) do
   end
 
   context "#set being called via the hook" do
+    let(:test_config) do
+      {
+        "source" => fixture_dir,
+        "quiet" => true,
+        "testing" => "123",
+        "destination" => tmp_dir,
+        "future" => true
+      }
+    end
+
     it "sets configuration defaults" do
       expect(site.config["kramdown"]["input"]).to eql("GFM")
     end
@@ -66,6 +77,7 @@ describe(GitHubPages::Configuration) do
 
     it "honors the user's config" do
       expect(site.config["some_key"]).to eql("some_value")
+      expect(site.config["future"]).to eql(true)
     end
 
     it "sets overrides" do


### PR DESCRIPTION
The GitHub Pages servers run in the `America/Los_Angeles` timezone. If one of our users in London or Hong Kong creates a post, its date will **automatically have the `America/Los_Angeles` timezone unless otherwise specified**. If a Londoner wishes to ship a post on June 30, they **must wait until it is June 30 _in Los Angeles_ to build**.

This change effectively publishes ALL posts in the `_posts` directory that do not have `published: false`.