### PR TITLE
Bump rouge to v1.11.1

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -13,7 +13,7 @@ module GitHubPages
 
       # Misc
       "liquid"                    => "3.0.6",
-      "rouge"                     => "1.11.0",
+      "rouge"                     => "1.11.1",
       "github-pages-health-check" => "1.1.0",
 
       # Plugins


### PR DESCRIPTION
**Release**: https://github.com/jneen/rouge/blob/v1.11.1/CHANGELOG.md
**Diff**:  https://github.com/jneen/rouge/compare/v1.11.0...v1.11.1

Follow-up to #297 and #296.

