### PR TITLE
Bump jekyll-redirect-from to v0.11.0

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -19,7 +19,7 @@ module GitHubPages
       # Plugins
       "jemoji"                    => "0.6.2",
       "jekyll-mentions"           => "1.1.3",
-      "jekyll-redirect-from"      => "0.10.0",
+      "jekyll-redirect-from"      => "0.11.0",
       "jekyll-sitemap"            => "0.10.0",
       "jekyll-feed"               => "0.5.1",
       "jekyll-gist"               => "1.4.0",


### PR DESCRIPTION
### PRs merged since **v0.10.0**

* Redirect page should not have any layout ([#106](https://github.com/jekyll/jekyll-redirect-from/pull/106))
* Include absolute path in canonical url ([#109](https://github.com/jekyll/jekyll-redirect-from/pull/109))
* Add tag and language ([#100](https://github.com/jekyll/jekyll-redirect-from/pull/100))
* Ensure redirect_to links produce an HTML file. ([#111](https://github.com/jekyll/jekyll-redirect-from/pull/111))

[Complete list of changes](https://github.com/jekyll/jekyll-redirect-from/compare/v0.10.0...v0.11.0)