### PR TITLE
script/bump: an automated way up bumping the gem version

### DIFF
--- a/script/bump
+++ b/script/bump
@@ -14,3 +14,8 @@ git commit -m "Bump :gem: to v$NEW_VERSION"
 git push origin master
 
 script/release
+
+echo "Ok! v$NEW_VERSION is released."
+echo "Please fill out the release: https://github.com/github/pages-gem/releases/tag/v$NEW_VERSION"
+echo "Here's the git history since the last release:"
+git log --one-line v$OLD_VERSION...v$NEW_VERSION

--- a/script/bump
+++ b/script/bump
@@ -1,0 +1,16 @@
+#!/bin/bash -ex
+
+(git branch | grep -q '* master') || {
+  echo "Only release from the master branch."
+  exit 1
+}
+
+VERSION_FILE="./lib/github-pages/version.rb"
+OLD_VERSION=$(curl "https://rubygems.org/api/v1/versions/github-pages/latest.json" | jq -r .version)
+NEW_VERSION=$(expr $OLD_VERSION + 1)
+echo -e "module GitHubPages\n  VERSION = $NEW_VERSION\nend" > $VERSION_FILE
+git add $VERSION_FILE
+git commit -m "Bump :gem: to v$NEW_VERSION"
+git push origin master
+
+script/release


### PR DESCRIPTION
When we bump the gem version presently, it's a manual process: open `lib/github-pages/version.rb`, manually bump the value of `VERSION`, commit the change, push, then run `script/release`.

What if we _automated_ that process? Automated bumping based on the latest version on RubyGems.org, automated descriptive commit message, and more?

Look no further, `script/bump` is here. Once you have merged all the pull requests you wish to release, pull down the latest `master` branch and run `script/bump`. That's it! You're done! Isn't that amazing!

/cc @github/pages