### PR TITLE
dependencies: pin activesupport to v4.2.7

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -30,7 +30,10 @@ module GitHubPages
 
       # Pin listen because it's broken on 2.1 & that's what we recommend.
       # https://github.com/guard/listen/pull/371
-      "listen"                    => "3.0.6"
+      "listen"                    => "3.0.6",
+
+      # Pin activesupport because 5.0 is broken on 2.1
+      "activesupport"             => "4.2.7"
     }.freeze
 
     # Jekyll and related dependency versions as used by GitHub Pages.

--- a/spec/github-pages-dependencies_spec.rb
+++ b/spec/github-pages-dependencies_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe(GitHubPages::Dependencies) do
   CORE_DEPENDENCIES = %w(
     jekyll kramdown liquid rouge jekyll-sass-converter
-    github-pages-health-check listen
+    github-pages-health-check listen activesupport
   ).freeze
   PLUGINS = described_class::VERSIONS.keys - CORE_DEPENDENCIES
 


### PR DESCRIPTION
Temporary fix until these are fixed:

- https://github.com/jekyll/jemoji/issues/46
- https://github.com/jekyll/jekyll-mentions/issues/36

/cc @github/pages