### PR TITLE
Whitelist Jekyll Admin locally

### DIFF
--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -91,7 +91,7 @@ module GitHubPages
       end
 
       def disable_whitelist?
-        Jekyll.env == "development" && !ENV["DISABLE_WHITELIST"].to_s.empty?
+        development? && !ENV["DISABLE_WHITELIST"].to_s.empty?
       end
 
       def development?

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -25,6 +25,11 @@ module GitHubPages
       jemoji
     ).freeze
 
+    # Plugins only allowed locally
+    DEVELOPMENT_PLUGINS = %w(
+      jekyll-admin
+    ).freeze
+
     # Default, user overwritable options
     DEFAULTS = {
       "jailed"   => false,
@@ -89,6 +94,10 @@ module GitHubPages
         Jekyll.env == "development" && !ENV["DISABLE_WHITELIST"].to_s.empty?
       end
 
+      def development?
+        Jekyll.env == "development"
+      end
+
       # Given a user's config, determines the effective configuration by building a user
       # configuration sandwhich with our overrides overriding the user's specified
       # values which themselves override our defaults.
@@ -108,6 +117,7 @@ module GitHubPages
         # Ensure we have those gems we want.
         config["gems"] = Array(config["gems"]) | DEFAULT_PLUGINS
         config["whitelist"] = config["whitelist"] | config["gems"] if disable_whitelist?
+        config["whitelist"] = config["whitelist"] | DEVELOPMENT_PLUGINS if development?
 
         config
       end


### PR DESCRIPTION
This PR creates a new class of whitelisted plugins called "development plugins", meaning they can be run locally, without disabling the whitelist, but won't run in other environments.

The idea being that we want users to be able to run Jekyll Admin locally, by simply adding it to their Gemfile, but there's not a use case for ever needing it in production, since it's designed to be used locally (thus no need to whitelist generally).

/cc @mertkahyaoglu for FYI, and @parkr for 👓 