### PR TITLE
Fix rubocop complaint about Fixnum vs Integer.

### DIFF
--- a/spec/github-pages_spec.rb
+++ b/spec/github-pages_spec.rb
@@ -2,6 +2,6 @@ require "spec_helper"
 
 describe(GitHubPages) do
   it "exposes its version" do
-    expect(described_class::VERSION).to be_a(Fixnum)
+    expect(described_class::VERSION).to be_a(Integer)
   end
 end


### PR DESCRIPTION
Introduced in Rubocop 0.43.0.