### PR TITLE
Bump jekyll to v3.3.0 (Updated version of #329)

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -5,7 +5,7 @@ module GitHubPages
   class Dependencies
     VERSIONS = {
       # Jekyll
-      "jekyll"                    => "3.2.1",
+      "jekyll"                    => "3.3.0",
       "jekyll-sass-converter"     => "1.3.0",
 
       # Converters

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -5,7 +5,7 @@ module GitHubPages
   class Dependencies
     VERSIONS = {
       # Jekyll
-      "jekyll"                    => "3.3.0",
+      "jekyll"                    => "3.3.0.pre.rc1",
       "jekyll-sass-converter"     => "1.3.0",
 
       # Converters

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -38,7 +38,7 @@ module GitHubPages
 
     # Themes
     THEMES = {
-      "minima"                    => "1.2.0",
+      "minima"                    => "2.0.0",
       "jekyll-swiss"              => "0.4.0"
     }.freeze
 

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -5,7 +5,7 @@ module GitHubPages
   class Dependencies
     VERSIONS = {
       # Jekyll
-      "jekyll"                    => "3.3.0.pre.rc1",
+      "jekyll"                    => "3.3.0",
       "jekyll-sass-converter"     => "1.3.0",
 
       # Converters


### PR DESCRIPTION
Update to date version of #329 

## Jekyll

**Release**: https://github.com/jekyll/jekyll/releases/tag/v3.3.0
**Diff**: jekyll/jekyll@v3.2.1...v3.3.0

## Minima

**Release**: https://github.com/jekyll/minima/releases/tag/v2.0.0
**Diff**: jekyll/minima@v1.2.0...v2.0.0