### PR TITLE
Bump jekyll-feed to v0.7.2 (Updated version of #330)

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -21,7 +21,7 @@ module GitHubPages
       "jekyll-mentions"           => "1.2.0",
       "jekyll-redirect-from"      => "0.11.0",
       "jekyll-sitemap"            => "0.10.0",
-      "jekyll-feed"               => "0.5.1",
+      "jekyll-feed"               => "0.7.2",
       "jekyll-gist"               => "1.4.0",
       "jekyll-paginate"           => "1.1.0",
       "jekyll-coffeescript"       => "1.0.1",

--- a/lib/github-pages/version.rb
+++ b/lib/github-pages/version.rb
@@ -1,3 +1,3 @@
 module GitHubPages
-  VERSION = 96
+  VERSION = 97
 end

--- a/lib/github-pages/version.rb
+++ b/lib/github-pages/version.rb
@@ -1,3 +1,3 @@
 module GitHubPages
-  VERSION = 97
+  VERSION = 98
 end


### PR DESCRIPTION
Update to date version of hubot's #330  

**Release**: https://github.com/jekyll/jekyll-feed/releases/tag/v0.7.2
**Diff**: jekyll/jekyll-feed@v0.5.1...v0.7.2