### PR TITLE
Add the jekyll-org plugin to the whitelist

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -27,6 +27,7 @@ module GitHubPages
       "jekyll-seo-tag"         => "2.1.0",
       "jekyll-github-metadata" => "2.3.1",
       "jekyll-avatar"          => "0.4.2",
+      "jekyll-org"             => "1.0.1",
 
       # Plugins to match GitHub.com Markdown
       "jemoji"                       => "0.7.0",

--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -34,6 +34,7 @@ module GitHubPages
       jekyll-default-layout
       jekyll-titles-from-headings
       jekyll-include-cache
+      jekyll-org
     ).freeze
 
     # Plugins only allowed locally


### PR DESCRIPTION
Add a plugin that makes it possible to use Org-mode for writing blog posts with GitHub Pages, without separate build steps & checking in generated HTML. The plugin used is a thin shim over the org-ruby module that GitHub already uses to render README.org files, so I am hoping that allowing it also for GitHub Pages won't be too much of a stretch.

Here's an example post using Org-mode properties:

```
#+title: Blogging with Jekyll-Org
#+layout: post
#+tags: Emacs

This is an example of blogging with =jekyll-org=. Note that both =YAML=
frontmatter and Org properties are supported.
```

The equivalent post using YAML frontmatter would look like this:

```

---
title: Blogging with Jekyll-Org
layout: post
tags: Emacs

---

This is an example of blogging with =jekyll-org=. Note that both =YAML=
frontmatter and Org properties are supported.
```
