### PR TITLE
Add jekyll-avatar

### DIFF
--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -23,6 +23,7 @@ module GitHubPages
       jekyll-redirect-from
       jekyll-seo-tag
       jekyll-sitemap
+      jekyll-avatar
       jemoji
     ).freeze
 

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -28,6 +28,7 @@ module GitHubPages
       "jekyll-coffeescript"       => "1.0.1",
       "jekyll-seo-tag"            => "2.1.0",
       "jekyll-github-metadata"    => "2.2.0",
+      "jekyll-avatar"             => "0.4.2",
 
       # Pin listen because it's broken on 2.1 & that's what we recommend.
       # https://github.com/guard/listen/pull/371


### PR DESCRIPTION
With the release of Jekyll Avatar 0.4.2, it now [uses Jekyll's built in `lookup_variable` method](https://github.com/benbalter/jekyll-avatar/blob/cfbcf5b8e7ceb454a58f657efa4af98193253f7b/lib/jekyll-avatar.rb#L41), so I'm more confident it'll work as expected in most contexts (which it didn't before).

Adding here to make it widely available and to fix things like https://github.com/jekyll/jekyll/issues/5535.