### PR TITLE
Only exclude 'node_modules'. Do not exclude 'vendor'

### DIFF
--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -37,6 +37,7 @@ module GitHubPages
       "jailed"   => false,
       "gems"     => DEFAULT_PLUGINS,
       "future"   => true,
+      "exclude"  => %w{node_modules},
       "kramdown" => {
         "input"     => "GFM",
         "hard_wrap" => false

--- a/spec/github-pages-configuration_spec.rb
+++ b/spec/github-pages-configuration_spec.rb
@@ -19,6 +19,7 @@ describe(GitHubPages::Configuration) do
   context "#effective_config" do
     it "sets configuration defaults" do
       expect(effective_config["kramdown"]["input"]).to eql("GFM")
+      expect(effective_config["exclude"]).to eql(["node_modules"])
       expect(effective_config["future"]).to eql(false)
     end
 


### PR DESCRIPTION
Many GitHub Pages users use `vendor/` to store third-party JavaScript, CSS, and other assets they incorporate into their sites. It is a widely-used standard for storing these kinds of assets.

A quick fix is to move all vendored assets data to the `assets/` directory, but that means the user is required to intervene to fix something that previously worked.

/cc @github/pages