### PR TITLE
Remove >= from Bundler issue warning in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ A simple Ruby Gem to bootstrap dependencies for setting up and maintaining a loc
 ## Usage
 
 1. Add the following to your project's Gemfile:  
-_Note: Forcing the version with `'>=104'` is a temporary workaround to avoid [this Bundler issue](https://github.com/bundler/bundler/issues/5154)._
+_Note: Forcing the version with `'104'` is a temporary workaround to avoid [this Bundler issue](https://github.com/bundler/bundler/issues/5154)._
 
   ```ruby
-  gem 'github-pages', '>=104', group: :jekyll_plugins
+  gem 'github-pages', '104', group: :jekyll_plugins
   ```
 
 2. Run `bundle install`


### PR DESCRIPTION
Currently Bundler will not fetch the latest version of the `github-pages` gem if the version is specified with `>=nnn` in the Gemfile.

Removing this from the README since it may lead users to assume differently. 