### PR TITLE
Add jekyll relative links

### DIFF
--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -10,6 +10,7 @@ module GitHubPages
       jekyll-gist
       jekyll-github-metadata
       jekyll-paginate
+      jekyll-relative-links
     ).freeze
 
     # Plugins allowed by GitHub Pages
@@ -24,6 +25,7 @@ module GitHubPages
       jekyll-seo-tag
       jekyll-sitemap
       jekyll-avatar
+      jekyll-relative-links
       jemoji
     ).freeze
 

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -29,7 +29,7 @@ module GitHubPages
       "jekyll-seo-tag"            => "2.1.0",
       "jekyll-github-metadata"    => "2.2.0",
       "jekyll-avatar"             => "0.4.2",
-      "jekyll-relative-links"     => "0.2.0",
+      "jekyll-relative-links"     => "0.2.1",
 
       # Pin listen because it's broken on 2.1 & that's what we recommend.
       # https://github.com/guard/listen/pull/371

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -29,6 +29,7 @@ module GitHubPages
       "jekyll-seo-tag"            => "2.1.0",
       "jekyll-github-metadata"    => "2.2.0",
       "jekyll-avatar"             => "0.4.2",
+      "jekyll-relative-links"     => "0.2.0",
 
       # Pin listen because it's broken on 2.1 & that's what we recommend.
       # https://github.com/guard/listen/pull/371

--- a/lib/github-pages/version.rb
+++ b/lib/github-pages/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GitHubPages
   VERSION = 105
 end


### PR DESCRIPTION
This PR adds [Jekyll relative links](https://github.com/benbalter/jekyll-relative-links), to add relative link support, as is already available for Markdown rendering on GitHub.com