### PR TITLE
Whitelist jekyll-include-cache

### DIFF
--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -33,6 +33,7 @@ module GitHubPages
       jekyll-readme-index
       jekyll-default-layout
       jekyll-titles-from-headings
+      jekyll-include-cache
     ).freeze
 
     # Plugins only allowed locally

--- a/spec/github-pages/plugins_spec.rb
+++ b/spec/github-pages/plugins_spec.rb
@@ -13,6 +13,7 @@ describe(GitHubPages::Plugins) do
   context "versions all whitelisted plugins" do
     GitHubPages::Plugins::PLUGIN_WHITELIST.each do |plugin|
       it "versions the #{plugin} plugin" do
+        next if plugin == "jekyll-include-cache"
         expect(GitHubPages::Dependencies::VERSIONS.keys).to include(plugin)
       end
     end


### PR DESCRIPTION
This PR whitelists [Jekyll Include Cache](https://github.com/benbalter/jekyll-include-cache), in support of https://github.com/kubernetes/kubernetes.github.io/pull/1994.

I'm suggesting that we whitelist the plugin, since it's a small wrapper around the existing Jekyll include tag, but not version it, as I suspect it'll only be used by large sites (and has the potential to complicate/confuse newer users).

To use the plugin then, you'd have to add it explicitly to your Gemfile, and it will not be versioned (or installed by default), but will be whitelisted for use locally and on GitHub Pages.

@parkr I'd really like your critical input on this one, since this is the first time we're doing this (and the list of plugins is getting long).