### PR TITLE
Upgrade Rubocop to 0.46 and add frozen string literal comment.

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency("mercenary", "~> 0.3")
   s.add_dependency("terminal-table", "~> 1.4")
   s.add_development_dependency("rspec", "~> 3.3")
-  s.add_development_dependency("rubocop", "~> 0.35")
+  s.add_development_dependency("rubocop", "~> 0.46")
   s.add_development_dependency("pry", "~> 0.10")
   s.add_development_dependency("jekyll_test_plugin_malicious", "~> 0.2")
 end

--- a/lib/github-pages/version.rb
+++ b/lib/github-pages/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GitHubPages
   VERSION = 108
 end


### PR DESCRIPTION
Nice to upgrade every once in a while.