### PR TITLE
Add Style/TrailingCommaInLiteral which enforces consistent commas in multiline literals.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -129,6 +129,7 @@ Style/FirstParameterIndentation: { EnforcedStyle: consistent }
 Style/StringLiterals: { EnforcedStyle: double_quotes }
 Style/IndentArray: { EnforcedStyle: consistent }
 Style/ExtraSpacing: { AllowForAlignment: true }
+Style/TrailingCommaInLiteral: { EnforcedStyleForMultiline: consistent_comma }
 
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -18,8 +18,8 @@ module GitHubPages
       "theme"    => "jekyll-theme-primer",
       "kramdown" => {
         "input"     => "GFM",
-        "hard_wrap" => false
-      }
+        "hard_wrap" => false,
+      },
     }.freeze
 
     # Jekyll defaults merged with Pages defaults.
@@ -48,11 +48,11 @@ module GitHubPages
       "kramdown"    => {
         "template"           => "",
         "math_engine"        => "mathjax",
-        "syntax_highlighter" => "rouge"
+        "syntax_highlighter" => "rouge",
       },
       "gist"        => {
-        "noscript"  => false
-      }
+        "noscript"  => false,
+      },
     }.freeze
 
     # These configuration settings have corresponding instance variables on

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -42,7 +42,7 @@ module GitHubPages
       "listen"                    => "3.0.6",
 
       # Pin activesupport because 5.0 is broken on 2.1
-      "activesupport"             => "4.2.7"
+      "activesupport"             => "4.2.7",
     }.freeze
 
     # Jekyll and related dependency versions as used by GitHub Pages.
@@ -70,7 +70,7 @@ module GitHubPages
         "github-pages"  => VERSION.to_s,
         "html-pipeline" => HTML::Pipeline::VERSION,
         "sass"          => Sass.version[:number],
-        "safe_yaml"     => SafeYAML::VERSION
+        "safe_yaml"     => SafeYAML::VERSION,
       }
     end
   end

--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -57,7 +57,7 @@ module GitHubPages
       "jekyll-theme-modernist"     => "0.0.3",
       "jekyll-theme-slate"         => "0.0.3",
       "jekyll-theme-tactile"       => "0.0.3",
-      "jekyll-theme-time-machine"  => "0.0.3"
+      "jekyll-theme-time-machine"  => "0.0.3",
     }.freeze
   end
 end

--- a/lib/github-pages/version.rb
+++ b/lib/github-pages/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GitHubPages
   VERSION = 113
 end

--- a/spec/github-pages/configuration_spec.rb
+++ b/spec/github-pages/configuration_spec.rb
@@ -7,7 +7,7 @@ describe(GitHubPages::Configuration) do
       "source" => fixture_dir,
       "quiet" => true,
       "testing" => "123",
-      "destination" => tmp_dir
+      "destination" => tmp_dir,
     }
   end
   let(:configuration) { Jekyll.configuration(test_config) }
@@ -60,7 +60,7 @@ describe(GitHubPages::Configuration) do
         "quiet" => true,
         "testing" => "123",
         "destination" => tmp_dir,
-        "future" => true
+        "future" => true,
       }
     end
 


### PR DESCRIPTION
[Rubocop documentation for this cop](http://rubocop.readthedocs.io/en/latest/cops_style/#styletrailingcommainliteral).

This PR enforces commas at the end of multiline hash and array literals, e.g.:

```ruby
deps = {
  "jekyll" => "1.2.3",
  "rubocop" => "0.46.0"
}

deps = {
  "jekyll" => "1.2.3",
  "rubocop" => "0.46.0",
}
```

I am proposing this for several reasons:

1. Git diffs when you add a new line don't show modification to any *other* lines (git history remains clean on a line-by-line basis)
2. Consistent commas mean you can rearrange the values in these literals without worrying about missing a comma somewhere -- each line has a comma so each line can go before or after any other line.