### PR TITLE
Lock nokogiri to 1.6 because 1.7 dropped support for Ruby 2.0

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -45,7 +45,7 @@ module GitHubPages
       "activesupport"             => "4.2.7",
 
       # Pin nokogiri to 1.6 because 1.7 dropped support for Ruby 2.0.
-      "nokogiri"                  => "1.6.8.1",
+      "nokogiri"                  => "1.6.8.1"
     }.freeze
 
     # Jekyll and related dependency versions as used by GitHub Pages.

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -42,7 +42,10 @@ module GitHubPages
       "listen"                    => "3.0.6",
 
       # Pin activesupport because 5.0 is broken on 2.1
-      "activesupport"             => "4.2.7"
+      "activesupport"             => "4.2.7",
+
+      # Pin nokogiri to 1.6 because 1.7 dropped support for Ruby 2.0.
+      "nokogiri"                  => "1.6.8.1",
     }.freeze
 
     # Jekyll and related dependency versions as used by GitHub Pages.

--- a/lib/github-pages/version.rb
+++ b/lib/github-pages/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GitHubPages
   VERSION = 113
 end

--- a/spec/github-pages/dependencies_spec.rb
+++ b/spec/github-pages/dependencies_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 describe(GitHubPages::Dependencies) do
   CORE_DEPENDENCIES = %w(
     jekyll kramdown liquid rouge jekyll-sass-converter
-    github-pages-health-check listen activesupport
+    github-pages-health-check listen activesupport nokogiri
   ).freeze
   PLUGINS = described_class::VERSIONS.keys - CORE_DEPENDENCIES
 


### PR DESCRIPTION
Ruby 2.0 is the version of Ruby that is installed by default on Mac OS X. Many of our users utilize this and we should do our best to keep compatibility.