### PR TITLE
Lock rainbow to 2.1.x

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency("terminal-table", "~> 1.4")
   s.add_development_dependency("rspec", "~> 3.3")
   s.add_development_dependency("rubocop", "~> 0.35")
+  s.add_development_dependency("rainbow", "~> 2.1.0")
   s.add_development_dependency("pry", "~> 0.10")
   s.add_development_dependency("jekyll_test_plugin_malicious", "~> 0.2")
 end


### PR DESCRIPTION
This can be removed once https://github.com/sickill/rainbow/pull/46 ships.