### PR TITLE
Allows for a custom redirect.html template to be included in _layouts.

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -18,7 +18,7 @@ module GitHubPages
       "github-pages-health-check" => "1.3.0",
 
       # Plugins
-      "jekyll-redirect-from"   => "0.11.0",
+      "jekyll-redirect-from"   => "0.12.1",
       "jekyll-sitemap"         => "0.12.0",
       "jekyll-feed"            => "0.8.0",
       "jekyll-gist"            => "1.4.0",


### PR DESCRIPTION
Back in November a pull request was accepted the amongst other enhancements allows for a custom redirect page to be provided in the layouts folder.

https://github.com/jekyll/jekyll-redirect-from/pull/131

I was looking to track some marketing materials that we're sending out and have a Google Analytics event sent in whenever someone hits a redirect at a specific URL.

I have created my own fork where I bumped up the version of jekyll-redirect-from in dependencies to 0.12.1.

This does allow for redirect.html to be customized...

<img width="782" alt="screen shot 2017-01-12 at 3 51 54 pm" src="https://cloud.githubusercontent.com/assets/116142/21907797/1080994e-d8df-11e6-84d6-d6ebc49c9714.png">

Compared to jekyll-redirect-from's static page:

<img width="684" alt="screen shot 2017-01-12 at 3 52 58 pm" src="https://cloud.githubusercontent.com/assets/116142/21907830/43d57698-d8df-11e6-912e-718d5fafc623.png">

This does bump the required version of nokogiri to 1.7.0.1

```
etching https://github.com/jchapin/pages-gem
Fetching gem metadata from https://rubygems.org/..........
Fetching version metadata from https://rubygems.org/..
Fetching dependency metadata from https://rubygems.org/.
Resolving dependencies...
Using i18n 0.7.0
Using json 1.8.5
Using minitest 5.10.1
Using thread_safe 0.3.5
Using public_suffix 2.0.5
Using coffee-script-source 1.12.2
Using execjs 2.7.0
Using colorator 1.1.0
Using ffi 1.9.14
Using multipart-post 2.0.0
Using forwardable-extended 2.6.0
Using gemoji 2.1.0
Using net-dns 0.8.0
Using sass 3.4.23
Using rb-fsevent 0.9.8
Using kramdown 1.11.1
Using liquid 3.0.6
Using mercenary 0.3.6
Using rouge 1.11.1
Using safe_yaml 1.0.4
Using mini_portile2 2.1.0
Using jekyll-paginate 1.1.0
Using jekyll-swiss 0.4.0
Using minima 2.0.0
Using unicode-display_width 1.1.2
Using bundler 1.13.6
Using tzinfo 1.2.2
Using addressable 2.5.0
Using coffee-script 2.4.1
Using ethon 0.10.1
Using rb-inotify 0.9.7
Using faraday 0.10.1
Using pathutil 0.14.0
Using jekyll-sass-converter 1.3.0
Installing nokogiri 1.6.8.1 (was 1.7.0.1) with native extensions
Using terminal-table 1.7.3
Using activesupport 4.2.7
Using jekyll-coffeescript 1.0.1
Using typhoeus 0.8.0
Using listen 3.0.6
Using sawyer 0.8.1
Using html-pipeline 2.4.2
Using jekyll-watch 1.5.0
Using octokit 4.6.2
Using jekyll 3.3.1
Using github-pages-health-check 1.3.0
Using jekyll-gist 1.4.0
Using jekyll-avatar 0.4.2
Using jekyll-default-layout 0.1.4
Using jekyll-feed 0.8.0
Using jekyll-github-metadata 2.3.0
Using jekyll-mentions 1.2.0
Using jekyll-optional-front-matter 0.1.2
Using jekyll-readme-index 0.0.3
Using jekyll-redirect-from 0.12.1 (was 0.11.0)
Using jekyll-relative-links 0.2.1
Using jekyll-seo-tag 2.1.0
Using jekyll-sitemap 0.12.0
Using jekyll-theme-architect 0.0.3
Using jekyll-theme-cayman 0.0.3
Using jekyll-theme-dinky 0.0.3
Using jekyll-theme-hacker 0.0.3
Using jekyll-theme-leap-day 0.0.3
Using jekyll-theme-merlot 0.0.3
Using jekyll-theme-midnight 0.0.3
Using jekyll-theme-minimal 0.0.3
Using jekyll-theme-modernist 0.0.3
Using jekyll-theme-primer 0.1.5
Using jekyll-theme-slate 0.0.3
Using jekyll-theme-tactile 0.0.3
Using jekyll-theme-time-machine 0.0.3
Using jekyll-titles-from-headings 0.1.3
Using jemoji 0.7.0
Using github-pages 113 from https://github.com/jchapin/pages-gem (at bump-redirect-from-to-0-12-1@016581a)
Bundle updated!
```