### PR TITLE
Bump kramdown to v1.13.2, and also explicitly set gfm_quirks option to paragraph_end

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ bundle exec github-pages versions
 +---------------------------+---------+
 | jekyll                    | 3.3.1   |
 | jekyll-sass-converter     | 1.3.0   |
-| kramdown                  | 1.11.1  |
+| kramdown                  | 1.13.2  |
 | liquid                    | 3.0.6   |
 | rouge                     | 1.11.1  |
 | github-pages-health-check | 1.3.0   |

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -19,6 +19,7 @@ module GitHubPages
       "kramdown" => {
         "input"     => "GFM",
         "hard_wrap" => false,
+        "gfm_quirks" => "paragraph_end",
       },
     }.freeze
 

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -10,7 +10,7 @@ module GitHubPages
       "jekyll-sass-converter"     => "1.5.0",
 
       # Converters
-      "kramdown"                  => "1.11.1",
+      "kramdown"                  => "1.13.2",
 
       # Misc
       "liquid"                    => "3.0.6",


### PR DESCRIPTION
Enabling gfm_quirks by default as mentioned by @benbalter in https://github.com/github/pages-gem/pull/398