### PR TITLE
Bump jekyll-relative-links to v0.3.0 - Allow for fragment support

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -31,7 +31,7 @@ module GitHubPages
       # Plugins to match GitHub.com Markdown
       "jemoji"                       => "0.7.0",
       "jekyll-mentions"              => "1.2.0",
-      "jekyll-relative-links"        => "0.2.1",
+      "jekyll-relative-links"        => "0.3.0",
       "jekyll-optional-front-matter" => "0.1.2",
       "jekyll-readme-index"          => "0.0.3",
       "jekyll-default-layout"        => "0.1.4",


### PR DESCRIPTION
jekyll-relative-links v0.3.0 supports relative links with fragments

benbalter/jekyll-relative-links#10
