### PR TITLE
Pin `redcarpet` to 3.4.0 to fix non-ASCII anchors

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -46,6 +46,10 @@ module GitHubPages
 
       # Pin nokogiri to 1.6 because 1.7 dropped support for Ruby 2.0.
       "nokogiri"                  => "1.6.8.1",
+
+      # Pin redcarpet because 3.4.0 fix non-ASCII anchors
+      # https://github.com/vmg/redcarpet/pull/591
+      "redcarpet"                 => "3.4.0",
     }.freeze
 
     # Jekyll and related dependency versions as used by GitHub Pages.

--- a/spec/github-pages/dependencies_spec.rb
+++ b/spec/github-pages/dependencies_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 describe(GitHubPages::Dependencies) do
   CORE_DEPENDENCIES = %w(
     jekyll kramdown liquid rouge jekyll-sass-converter
-    github-pages-health-check listen activesupport nokogiri
+    github-pages-health-check listen activesupport nokogiri redcarpet
   ).freeze
   PLUGINS = described_class::VERSIONS.keys - CORE_DEPENDENCIES
 


### PR DESCRIPTION
PR: https://github.com/vmg/redcarpet/pull/591

Broken pages example: https://mozilla.github.io/nunjucks/cn/templating.html
Scroll down a little

Broken pages source code: https://github.com/mozilla/nunjucks/blob/gh-pages/cn/templating.html#L202
The missing quote make some tags closed incorrectly.