### PR TITLE
Add an automatic version check.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,9 @@ Lint/AmbiguousRegexpLiteral:
   Exclude:
     - 'features/step_definitions/pages_steps.rb'
 
+Style/ModuleFunction:
+  Enabled: false
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
   Severity: error

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -8,6 +8,7 @@ module GitHubPages
   autoload :Configuration, "github-pages/configuration"
   autoload :Dependencies,  "github-pages/dependencies"
   autoload :VERSION,       "github-pages/version"
+  autoload :VersionCheck,  "github-pages/version_check"
 
   def self.versions
     Dependencies.versions
@@ -16,4 +17,8 @@ end
 
 Jekyll::Hooks.register :site, :after_reset do |site|
   GitHubPages::Configuration.set(site)
+end
+
+Jekyll::Hooks.register :site, :after_init do
+  GitHubPages::VersionCheck.run!
 end

--- a/lib/github-pages/version_check.rb
+++ b/lib/github-pages/version_check.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require "typhoeus"
+
+module GitHubPages
+  # VersionCheck ensures that the local version is up to date with the
+  # latest version deployed to GitHub Pages.
+  module VersionCheck
+    PRODUCTION_VERSIONS_URL = "https://pages.github.com/versions.json"
+
+    def run!
+      @already_run ||=
+        begin
+          return true if ENV["PAGES_ENV"].to_s.casecmp("enterprise").zero?
+
+          if GitHubPages::VERSION < production_ghp_version
+            Jekyll.logger.error "GitHub Pages:", "You are using an outdated version of github-pages."
+            Jekyll.logger.error "", "Upgrade to version '#{production_ghp_version}' to ensure your local builds"
+            Jekyll.logger.error "", "will accurately reflect what is deployed when you push to GitHub."
+            return false
+          end
+
+          true
+        end
+    end
+
+    def production_versions_url
+      @production_versions_url ||= PRODUCTION_VERSIONS_URL
+    end
+
+    def production_ghp_version
+      @production_ghp_version ||= production_versions["github-pages"].to_i
+    end
+
+    def production_versions
+      @production_versions ||=
+        begin
+          response = http_get_with_retries(production_versions_url)
+          JSON.parse(response.response_body)
+        end
+    end
+
+    extend self
+
+    private
+
+    # rubocop:disable Lint/HandleExceptions
+    def http_get_with_retries(url)
+      1.upto(5) do
+        begin
+          response = Typhoeus.get(url)
+          return response if response && response.success?
+        rescue
+        end
+      end
+    end
+    # rubocop:enable Lint/HandleExceptions
+  end
+end


### PR DESCRIPTION
Ensuring that you're up to date with the latest github-pages version means you'll be accurately building your site locally to match the eventual Pages production deploy.

@benbalter, what do you think about this?