### PR TITLE
Add script to audit dependency versions

### DIFF
--- a/script/audit-versions
+++ b/script/audit-versions
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+
+require_relative "../lib/github-pages"
+require 'json'
+require 'open-uri'
+require 'terminal-table'
+
+def latest_version(gem_name)
+  uri = "https://rubygems.org/api/v1/versions/#{gem_name}/latest.json"
+  data = open(uri).read
+  JSON.parse(data)["version"]
+end
+
+rows = []
+GitHubPages::Dependencies.gems.each do |gem_name, version|
+  latest = latest_version(gem_name)
+  rows << [gem_name, version, latest] unless version == latest
+end
+
+if rows.empty?
+  puts "Nice work! Everything's up to date."
+else
+  puts "Here are the gems that are out of date:"
+  puts Terminal::Table.new :headings => ["Gem", "Current", "Latest"], :rows => rows
+end

--- a/script/test-site
+++ b/script/test-site
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Test that the default Jekyll site builds
+
+set -e
+
+rm -Rf ./test-site
+bundle exec jekyll new test-site
+
+BUNDLE_GEMFILE="$(pwd)/Gemfile"
+export BUNDLE_GEMFILE
+
+cd test-site
+rm -Rf Gemfile
+
+echo "Using $(bundle exec github-pages --version)"
+echo "Using $(bundle exec jekyll --version)"
+bundle exec jekyll build --trace --verbose
+
+grep --quiet "Your awesome title" ./_site/index.html
+echo "Site built!"
+
+cd ..
+rm -Rf ./test-site


### PR DESCRIPTION
This PR adds a quick script to audit which, if any dependencies are behind the latest released version. Of course, in some cases, such as Liquid, our hands are tied until changes are made upstream, but at least can serve as a quick way to see which plugins/themes need to be updated. 

Here's what the output looks like:

```
Here are the gems that are out of date:
+---------------------+---------+---------+
| Gem                 | Current | Latest  |
+---------------------+---------+---------+
| jekyll              | 3.3.1   | 3.4.0   |
| liquid              | 3.0.6   | 4.0.0   |
| rouge               | 1.11.1  | 2.0.7   |
| jekyll-feed         | 0.8.0   | 0.9.1   |
| jekyll-coffeescript | 1.0.1   | 1.0.2   |
| jekyll-readme-index | 0.0.4   | 0.1.0   |
| listen              | 3.0.6   | 3.1.5   |
| activesupport       | 4.2.7   | 5.0.1   |
| nokogiri            | 1.6.8.1 | 1.7.0.1 |
| minima              | 2.0.0   | 2.1.0   |
+---------------------+---------+---------+
```