### PR TITLE
Bump github pages health check to v1.3.1

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -15,7 +15,7 @@ module GitHubPages
       # Misc
       "liquid"                    => "3.0.6",
       "rouge"                     => "1.11.1",
-      "github-pages-health-check" => "1.3.0",
+      "github-pages-health-check" => "1.3.1",
 
       # Plugins
       "jekyll-redirect-from"   => "0.12.1",


### PR DESCRIPTION
This is in support of a Fastly datacenter deprecation. See https://github.com/github/pages-health-check/pull/66.