### PR TITLE
Update gem badge / CI against Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.3
+  - 2.4.0
 
 before_install: gem install bundler # update bundler.
 script: "script/cibuild"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple Ruby Gem to bootstrap dependencies for setting up and maintaining a local Jekyll environment in sync with GitHub Pages.
 
-[![Gem Version](https://img.shields.io/gem/v/github-pages.svg)](https://rubygems.org/gems/github-pages)
+[![Gem Version](https://badge.fury.io/rb/github-pages.svg)](https://badge.fury.io/rb/github-pages)
 [![Build Status](https://img.shields.io/travis/github/pages-gem/master.svg)](https://travis-ci.org/github/pages-gem)
 
 ## Usage


### PR DESCRIPTION
- Update gem badge to the latest
- CI against Ruby 2.4