### PR TITLE
Dockerization of GitHub Pages (WIP)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:2.3.3-alpine
+
+RUN mkdir /usr/src/app \
+  && apk update \
+  && apk upgrade \
+  && apk add --no-cache bash git make
+
+COPY . /usr/src/app
+
+WORKDIR /usr/src/app
+
+RUN gem build github-pages.gemspec
+
+CMD bundle install --gemfile=github-pages-127.gem


### PR DESCRIPTION
Creating this PR as a starting point for making GitHub Pages run in a Docker container. 

Try this out by cloning my fork locally, `cd`ing into the repo and running:

```
docker build -t myghpages .
```

Then, because this isn't running yet, you'll want to start a bash prompt from within the container:

```
docker run -ti --entrypoint=/bin/bash myghpages
```

From here you can see what has happened up to the point of the `CMD` line (which is overridden by `entrypoint`). There's a built `github-pages-127.gem` in your directory, but it doesn't seem to install, probably because I'm a newb and am missing something obvious. From within that prompt try running:

```
bundle install --gemfile=github-pages-127.gem
```

...And you'll see what I mean:

```
[!] There was an error parsing `github-pages-127.gem`: Undefined local variable or method `metadata' for Gemfile. Bundler cannot continue.

 #  from /usr/src/app/github-pages-127.gem:1
 #  -------------------------------------------
 >  metadata.gz0000444000000000000000000000247413060347710013446 0ustar00wheelwheel00000000000000???X?ao?6???)X??͠?d?t?i?t?I?????&?'????6?E????1?k?kO?]?XM[??1??/?<~l?Q?_?v?=??K?&{u???ekF?aR?Ԑ?%3U??R??@iܔ=????? 
                              ?V????Y?pb?R?Yh?	Hk*?tD?~lW_?o?m?T?w?6??(??B?PP&?ax???
 #  
 #  -------------------------------------------
```

cc @thajeztah, @mstanleyjones, @parkr 

Just a start; the people on the CC line are definitely capable of creating this, and I appreciate any advice from you guys. I can also advise GitHub on how to get an official image for GitHub Pages up on the Docker Store, and get it auto-building so pushes to this repo update the official image. But first, let's get it working. :)

The "Dockerization" of GitHub Pages would be tremendous; currently there is no official image and people are using janky things from the community (like `starefossen/github-pages`) which don't pass [Docker Security Scanner's security checks](https://docs.docker.com/docker-cloud/builds/image-scan/).

> Note: Once this is building properly, the bits in `CMD` should be moved up to `RUN` and `CMD` should probably get a pointer to `jekyll`as the real entrypoint