### PR TITLE
Remove strict Nokogiri dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gemspec

--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require File.expand_path("../lib/github-pages/dependencies", __FILE__)
 require File.expand_path("../lib/github-pages/plugins", __FILE__)
 require File.expand_path("../lib/github-pages/version", __FILE__)

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require "jekyll"
 

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "securerandom"
 
 module GitHubPages

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -45,7 +45,7 @@ module GitHubPages
       "activesupport"             => "4.2.7",
 
       # Pin nokogiri to 1.6 because 1.7 dropped support for Ruby 2.0.
-      "nokogiri"                  => "1.6.8.1",
+      "nokogiri"                  => "1.7.1",
     }.freeze
 
     # Jekyll and related dependency versions as used by GitHub Pages.

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -44,9 +44,6 @@ module GitHubPages
 
       # Pin activesupport because 5.0 is broken on 2.1
       "activesupport"             => "4.2.7",
-
-      # Pin nokogiri to 1.6 because 1.7 dropped support for Ruby 2.0.
-      "nokogiri"                  => "1.7.1",
     }.freeze
 
     # Jekyll and related dependency versions as used by GitHub Pages.
@@ -66,6 +63,7 @@ module GitHubPages
       require "html/pipeline/version"
       require "sass/version"
       require "safe_yaml/version"
+      require "nokogiri"
 
       {
         "ruby" => RUBY_VERSION,
@@ -75,6 +73,7 @@ module GitHubPages
         "html-pipeline" => HTML::Pipeline::VERSION,
         "sass"          => Sass.version[:number],
         "safe_yaml"     => SafeYAML::VERSION,
+        "nokogiri"      => Nokogiri::VERSION,
       }
     end
   end

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module GitHubPages
   # Dependencies is where all the public dependencies for GitHub Pages are defined,
   # and versions locked. Any plugin for Pages must be specified here with a

--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module GitHubPages
   # Manages the constants the govern what plugins are allows on GitHub Pages
   class Plugins

--- a/spec/github-pages/bin_spec.rb
+++ b/spec/github-pages/bin_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "spec_helper"
 
 describe(GitHubPages) do

--- a/spec/github-pages/configuration_spec.rb
+++ b/spec/github-pages/configuration_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "spec_helper"
 
 describe(GitHubPages::Configuration) do

--- a/spec/github-pages/dependencies_spec.rb
+++ b/spec/github-pages/dependencies_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe(GitHubPages::Dependencies) do
   CORE_DEPENDENCIES = %w(
     jekyll kramdown liquid rouge jekyll-sass-converter
-    github-pages-health-check listen activesupport nokogiri
+    github-pages-health-check listen activesupport
   ).freeze
   PLUGINS = described_class::VERSIONS.keys - CORE_DEPENDENCIES
 

--- a/spec/github-pages/dependencies_spec.rb
+++ b/spec/github-pages/dependencies_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "spec_helper"
 
 describe(GitHubPages::Dependencies) do

--- a/spec/github-pages/plugins_spec.rb
+++ b/spec/github-pages/plugins_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "spec_helper"
 
 describe(GitHubPages::Plugins) do

--- a/spec/github-pages_spec.rb
+++ b/spec/github-pages_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "spec_helper"
 
 describe(GitHubPages) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require File.expand_path("../../lib/github-pages.rb", __FILE__)
 
 RSpec.configure do |config|


### PR DESCRIPTION
Fixes https://github.com/github/pages-gem/issues/426.

Nokogiri >= 1.7.1 contains several security fixes. 

We'd previously pinned to 1.6.x in order to maintain out-of-the-box OS X Ruby support (2.0.0).

This PR removes the pinned dependency, allowing Ruby 2.0.0 users to use 1.6.x to maintain backwards compatibility, while enabling newer Ruby users to use 1.7.x.