### PR TITLE
Bump outdated jekyll-* dependencies

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -24,7 +24,7 @@ module GitHubPages
       "jekyll-feed"            => "0.9.2",
       "jekyll-gist"            => "1.4.0",
       "jekyll-paginate"        => "1.1.0",
-      "jekyll-coffeescript"    => "1.0.2",
+      "jekyll-coffeescript"    => "1.0.1",
       "jekyll-seo-tag"         => "2.1.0",
       "jekyll-github-metadata" => "2.3.1",
       "jekyll-avatar"          => "0.4.2",

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -21,10 +21,10 @@ module GitHubPages
       # Plugins
       "jekyll-redirect-from"   => "0.12.1",
       "jekyll-sitemap"         => "1.0.0",
-      "jekyll-feed"            => "0.9.1",
+      "jekyll-feed"            => "0.9.2",
       "jekyll-gist"            => "1.4.0",
       "jekyll-paginate"        => "1.1.0",
-      "jekyll-coffeescript"    => "1.0.1",
+      "jekyll-coffeescript"    => "1.0.2",
       "jekyll-seo-tag"         => "2.1.0",
       "jekyll-github-metadata" => "2.3.1",
       "jekyll-avatar"          => "0.4.2",
@@ -32,9 +32,9 @@ module GitHubPages
       # Plugins to match GitHub.com Markdown
       "jemoji"                       => "0.8.0",
       "jekyll-mentions"              => "1.2.0",
-      "jekyll-relative-links"        => "0.3.0",
+      "jekyll-relative-links"        => "0.4.0",
       "jekyll-optional-front-matter" => "0.1.2",
-      "jekyll-readme-index"          => "0.0.4",
+      "jekyll-readme-index"          => "0.1.0",
       "jekyll-default-layout"        => "0.1.4",
       "jekyll-titles-from-headings"  => "0.1.4",
 

--- a/lib/github-pages/version.rb
+++ b/lib/github-pages/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GitHubPages
-  VERSION = 130
+  VERSION = 131
 end

--- a/lib/github-pages/version.rb
+++ b/lib/github-pages/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GitHubPages
-  VERSION = 131
+  VERSION = 130
 end


### PR DESCRIPTION
### Jekyll Feed

* fix <entry> template for posts with post.lang defined 

### Jekyll Relative links

* Support for relative static files
* Save from 'invalid byte sequence' errors

### Jekyll README index

* Support for READMEs in subfolders
* README detection now respects global Markdown extension setting

