### PR TITLE
Enforce Kramdown as the Markdown engine

### DIFF
--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -17,6 +17,7 @@ module GitHubPages
       "gems"     => GitHubPages::Plugins::DEFAULT_PLUGINS,
       "future"   => true,
       "theme"    => "jekyll-theme-primer",
+      "markdown" => "kramdown",
       "kramdown" => {
         "input"     => "GFM",
         "hard_wrap" => false,

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -17,7 +17,6 @@ module GitHubPages
       "gems"     => GitHubPages::Plugins::DEFAULT_PLUGINS,
       "future"   => true,
       "theme"    => "jekyll-theme-primer",
-      "markdown" => "kramdown",
       "kramdown" => {
         "input"     => "GFM",
         "hard_wrap" => false,
@@ -48,6 +47,7 @@ module GitHubPages
       "plugins_dir" => SecureRandom.hex,
       "whitelist"   => GitHubPages::Plugins::PLUGIN_WHITELIST,
       "highlighter" => "rouge",
+      "markdown"    => "kramdown",
       "kramdown"    => {
         "template"           => "",
         "math_engine"        => "mathjax",


### PR DESCRIPTION
See https://github.com/blog/2151-github-pages-drops-support-for-rdiscount-redcarpet-and-redcloth-textile-markup-engines.