### PR TITLE
Bump github metadata, titles from headings, and relative links

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,10 +47,10 @@ Style/HashSyntax:
   EnforcedStyle: hash_rockets
   Severity: error
 
-Style/AlignHash:
+Layout/AlignHash:
   SupportedLastArgumentHashStyles: always_ignore
 
-Style/AlignParameters:
+Layout/AlignParameters:
   Enabled: false # This is usually true, but we often want to roll back to
                  # the start of a line.
 
@@ -94,7 +94,7 @@ Style/MultilineTernaryOperator:
 Style/AndOr:
   Severity: error
 
-Style/IndentationWidth:
+Layout/IndentationWidth:
   Severity: error
 
 Metrics/MethodLength:
@@ -121,14 +121,14 @@ Metrics/PerceivedComplexity: { Max: 8 }
 Metrics/ParameterLists: { Max: 4 }
 Metrics/AbcSize: { Max: 20 }
 
-Style/IndentHash: { EnforcedStyle: consistent }
+Layout/IndentHash: { EnforcedStyle: consistent }
 Style/SignalException: { EnforcedStyle: only_raise }
-Style/MultilineMethodCallIndentation: { EnforcedStyle: indented }
-Style/MultilineOperationIndentation: { EnforcedStyle: indented }
-Style/FirstParameterIndentation: { EnforcedStyle: consistent }
+Layout/MultilineMethodCallIndentation: { EnforcedStyle: indented }
+Layout/MultilineOperationIndentation: { EnforcedStyle: indented }
+Layout/FirstParameterIndentation: { EnforcedStyle: consistent }
 Style/StringLiterals: { EnforcedStyle: double_quotes }
-Style/IndentArray: { EnforcedStyle: consistent }
-Style/ExtraSpacing: { AllowForAlignment: true }
+Layout/IndentArray: { EnforcedStyle: consistent }
+Layout/ExtraSpacing: { AllowForAlignment: true }
 Style/TrailingCommaInLiteral: { EnforcedStyleForMultiline: consistent_comma }
 
 Style/PercentLiteralDelimiters:

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -36,7 +36,7 @@ module GitHubPages
       "jekyll-optional-front-matter" => "0.1.2",
       "jekyll-readme-index"          => "0.1.0",
       "jekyll-default-layout"        => "0.1.4",
-      "jekyll-titles-from-headings"  => "0.1.5",
+      "jekyll-titles-from-headings"  => "0.2.0",
 
       # Pin listen because it's broken on 2.1 & that's what we recommend.
       # https://github.com/guard/listen/pull/371

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -32,7 +32,7 @@ module GitHubPages
       # Plugins to match GitHub.com Markdown
       "jemoji"                       => "0.8.0",
       "jekyll-mentions"              => "1.2.0",
-      "jekyll-relative-links"        => "0.4.0",
+      "jekyll-relative-links"        => "0.4.1",
       "jekyll-optional-front-matter" => "0.1.2",
       "jekyll-readme-index"          => "0.1.0",
       "jekyll-default-layout"        => "0.1.4",

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -26,7 +26,7 @@ module GitHubPages
       "jekyll-paginate"        => "1.1.0",
       "jekyll-coffeescript"    => "1.0.1",
       "jekyll-seo-tag"         => "2.2.3",
-      "jekyll-github-metadata" => "2.3.1",
+      "jekyll-github-metadata" => "2.4.0",
       "jekyll-avatar"          => "0.4.2",
 
       # Plugins to match GitHub.com Markdown

--- a/spec/github-pages/configuration_spec.rb
+++ b/spec/github-pages/configuration_spec.rb
@@ -14,8 +14,11 @@ describe(GitHubPages::Configuration) do
   let(:configuration) { Jekyll.configuration(test_config) }
   let(:site)          { Jekyll::Site.new(configuration) }
   let(:effective_config) { described_class.effective_config(site.config) }
-  before(:each) { ENV.delete("DISABLE_WHITELIST") }
-  before(:each) { ENV["JEKYLL_ENV"] = "test" }
+  before(:each) do
+    ENV.delete("DISABLE_WHITELIST")
+    ENV["JEKYLL_ENV"] = "test"
+    ENV["PAGES_REPO_NWO"] = "github/pages-gem"
+  end
 
   context "#effective_config" do
     it "sets configuration defaults" do


### PR DESCRIPTION
[Bump jekyll-github-metadata to v2.4.0](https://github.com/github/pages-gem/pull/431),
[Bump jekyll-titles-from-headings to v0.2.0](https://github.com/github/pages-gem/pull/445), and
[Bump jekyll-relative-links to v0.4.1](https://github.com/github/pages-gem/pull/447)

Fixes #447, Fixes #445, Fixes #431