### PR TITLE
Bump primer to 0.3.0

### DIFF
--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -46,7 +46,7 @@ module GitHubPages
     THEMES = {
       "minima"                     => "2.1.1",
       "jekyll-swiss"               => "0.4.0",
-      "jekyll-theme-primer"        => "0.2.1",
+      "jekyll-theme-primer"        => "0.3.0",
       "jekyll-theme-architect"     => "0.0.4",
       "jekyll-theme-cayman"        => "0.0.4",
       "jekyll-theme-dinky"         => "0.0.4",


### PR DESCRIPTION
* Adds a default `H1` with `site.title` and a link to the site's index, if set
* Adds margin-top and margin-bottom to the body