### PR TITLE
Bump primer to v0.5.0

### DIFF
--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -46,7 +46,7 @@ module GitHubPages
     THEMES = {
       "minima"                     => "2.1.1",
       "jekyll-swiss"               => "0.4.0",
-      "jekyll-theme-primer"        => "0.4.0",
+      "jekyll-theme-primer"        => "0.5.0",
       "jekyll-theme-architect"     => "0.1.0",
       "jekyll-theme-cayman"        => "0.1.0",
       "jekyll-theme-dinky"         => "0.1.0",


### PR DESCRIPTION
This adds a "help improve this page" link to the footer if the site is public and has an open source license.