### PR TITLE
Bump primer to 0.5.2

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -26,7 +26,7 @@ module GitHubPages
       "jekyll-paginate"        => "1.1.0",
       "jekyll-coffeescript"    => "1.0.1",
       "jekyll-seo-tag"         => "2.3.0",
-      "jekyll-github-metadata" => "2.9.0",
+      "jekyll-github-metadata" => "2.9.1",
       "jekyll-avatar"          => "0.4.2",
 
       # Plugins to match GitHub.com Markdown

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -26,7 +26,7 @@ module GitHubPages
       "jekyll-paginate"        => "1.1.0",
       "jekyll-coffeescript"    => "1.0.1",
       "jekyll-seo-tag"         => "2.3.0",
-      "jekyll-github-metadata" => "2.8.0",
+      "jekyll-github-metadata" => "2.9.0",
       "jekyll-avatar"          => "0.4.2",
 
       # Plugins to match GitHub.com Markdown

--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -46,7 +46,7 @@ module GitHubPages
     THEMES = {
       "minima"                     => "2.1.1",
       "jekyll-swiss"               => "0.4.0",
-      "jekyll-theme-primer"        => "0.5.0",
+      "jekyll-theme-primer"        => "0.5.2",
       "jekyll-theme-architect"     => "0.1.0",
       "jekyll-theme-cayman"        => "0.1.0",
       "jekyll-theme-dinky"         => "0.1.0",


### PR DESCRIPTION
Which adds an "Edit this page" link to sites that are public and are licensed under an open source license. 

This does so via GitHub Metadata 2.9.1 which includes a [`github_edit_link` tag](https://jekyll.github.io/github-metadata/edit-on-github-link/). 

Additionally, https://github.com/pages-themes/primer is now open source. 🎉 