### PR TITLE
Ensure the default theme is used when previewing locally

### DIFF
--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -137,19 +137,7 @@ module GitHubPages
       # Set the site's configuration with all the proper defaults and overrides.
       # Should be called by #set to protect against multiple processings.
       def set!(site)
-        config = effective_config(site.config)
-
-        # Assign everything to the site
-        site.instance_variable_set :@config, config
-
-        # Ensure all
-        CONFIGS_WITH_METHODS.each do |opt|
-          site.public_send("#{opt}=", site.config[opt])
-        end
-
-        # While Configuration renamed the gems key to plugins, Site retained
-        # backwards compatability and must be set manually
-        site.gems = site.config["plugins"]
+        site.config = effective_config(site.config)
       end
     end
   end

--- a/spec/fixtures/jekyll-theme-primer.md
+++ b/spec/fixtures/jekyll-theme-primer.md
@@ -1,0 +1,4 @@
+---
+---
+
+Theme: {{ site.theme }}

--- a/spec/fixtures/jekyll-theme-primer.md
+++ b/spec/fixtures/jekyll-theme-primer.md
@@ -1,4 +1,5 @@
 ---
+layout: default
 ---
 
 Theme: {{ site.theme }}

--- a/spec/github-pages/configuration_spec.rb
+++ b/spec/github-pages/configuration_spec.rb
@@ -58,10 +58,27 @@ describe(GitHubPages::Configuration) do
       expect(effective_config["testing"]).to eql("123")
     end
 
-    it "sets the theme" do
-      expect(site.theme).to_not be_nil
-      expect(site.theme).to be_a(Jekyll::Theme)
-      expect(site.theme.name).to eql("jekyll-theme-primer")
+    context "themes" do
+      context "with no theme set" do
+        it "sets the theme" do
+          expect(site.theme).to_not be_nil
+          expect(site.theme).to be_a(Jekyll::Theme)
+          expect(site.theme.name).to eql("jekyll-theme-primer")
+        end
+      end
+
+      context "with a user-specified theme" do
+        let(:site) do
+          config = configuration.merge("theme" => "jekyll-theme-merlot")
+          Jekyll::Site.new(config)
+        end
+
+        it "respects the theme" do
+          expect(site.theme).to_not be_nil
+          expect(site.theme).to be_a(Jekyll::Theme)
+          expect(site.theme.name).to eql("jekyll-theme-merlot")
+        end
+      end
     end
 
     context "in development" do

--- a/spec/github-pages/configuration_spec.rb
+++ b/spec/github-pages/configuration_spec.rb
@@ -58,6 +58,12 @@ describe(GitHubPages::Configuration) do
       expect(effective_config["testing"]).to eql("123")
     end
 
+    it "sets the theme" do
+      expect(site.theme).to_not be_nil
+      expect(site.theme).to be_a(Jekyll::Theme)
+      expect(site.theme.name).to eql("jekyll-theme-primer")
+    end
+
     context "in development" do
       before { ENV["JEKYLL_ENV"] = "development" }
 

--- a/spec/github-pages/integration_spec.rb
+++ b/spec/github-pages/integration_spec.rb
@@ -212,4 +212,14 @@ RSpec.describe "Pages Gem Integration spec" do
       expect(contents).to match("README")
     end
   end
+
+  context "jekyll-theme-primer" do
+    it "sets the theme" do
+      expect(contents).to match("Theme: jekyll-theme-primer")
+    end
+
+    it "uses the theme" do
+      expect(contents).to match('<div class="container-lg px-3 my-5 markdown-body">')
+    end
+  end
 end


### PR DESCRIPTION
In https://github.com/github/pages-gem/pull/477 I noticed the default theme (Primer) was not being used when built locally, even though the configuration value was set. 

This was because we [were manually setting the instance variable `@config`](https://github.com/github/pages-gem/blob/d74c8bf0139cbc0b0340e0ac125dfbd839d39741/lib/github-pages/configuration.rb#L137-L153), rather than using the public [`config=` method](https://github.com/jekyll/jekyll/blob/fb27b2e296219943f3c6b563b21a2443b1337de1/lib/jekyll/site.rb#L40-L65), which does things like instantiante the theme object, set load paths, etc.

Reading through the code, I don't see any downside to using `config=` which also calls the `opt=` methods we were manually calling (in addition to preserving backwards compatibility around `plugins`/`gems`

