### PR TITLE
Bump sitemap, metadata, avatar, and coffeescript

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -20,14 +20,14 @@ module GitHubPages
 
       # Plugins
       "jekyll-redirect-from"   => "0.12.1",
-      "jekyll-sitemap"         => "1.0.0",
+      "jekyll-sitemap"         => "1.1.1",
       "jekyll-feed"            => "0.9.2",
       "jekyll-gist"            => "1.4.1",
       "jekyll-paginate"        => "1.1.0",
-      "jekyll-coffeescript"    => "1.0.1",
+      "jekyll-coffeescript"    => "1.0.2",
       "jekyll-seo-tag"         => "2.3.0",
-      "jekyll-github-metadata" => "2.9.1",
-      "jekyll-avatar"          => "0.4.2",
+      "jekyll-github-metadata" => "2.9.2",
+      "jekyll-avatar"          => "0.5.0",
 
       # Plugins to match GitHub.com Markdown
       "jemoji"                       => "0.8.0",

--- a/spec/fixtures/_config.yml
+++ b/spec/fixtures/_config.yml
@@ -12,3 +12,6 @@ gems:
   - jekyll_test_plugin_malicious
 quiet: false
 paginate: 5
+github:
+  source:
+    branch: gh-pages


### PR DESCRIPTION
Changes:

* Sitemap: https://github.com/jekyll/jekyll-sitemap/releases/tag/v1.1.0 (escape `&`, exclude `404`s) 
* Coffeescript: https://github.com/jekyll/jekyll-coffeescript/releases/tag/v1.0.2 (lazy load)
* Metadata: https://github.com/jekyll/github-metadata/releases/tag/v2.9.2 (user overrides)
* Avatar: https://github.com/benbalter/jekyll-avatar/releases/tag/v0.5.0 (Enterprise support)