### PR TITLE
Bump jekyll metadata to 2.9.3

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -26,7 +26,7 @@ module GitHubPages
       "jekyll-paginate"        => "1.1.0",
       "jekyll-coffeescript"    => "1.0.2",
       "jekyll-seo-tag"         => "2.3.0",
-      "jekyll-github-metadata" => "2.9.2",
+      "jekyll-github-metadata" => "2.9.3",
       "jekyll-avatar"          => "0.5.0",
 
       # Plugins to match GitHub.com Markdown


### PR DESCRIPTION
Fix for `site.github.*` values not being propagated in some cases (jekyll/github-metadata#112)