### PR TITLE
Bump activated by default plugins to latest version

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -32,11 +32,11 @@ module GitHubPages
       # Plugins to match GitHub.com Markdown
       "jemoji"                       => "0.8.0",
       "jekyll-mentions"              => "1.2.0",
-      "jekyll-relative-links"        => "0.4.1",
-      "jekyll-optional-front-matter" => "0.2.0",
-      "jekyll-readme-index"          => "0.1.0",
+      "jekyll-relative-links"        => "0.5.0",
+      "jekyll-optional-front-matter" => "0.3.0",
+      "jekyll-readme-index"          => "0.2.0",
       "jekyll-default-layout"        => "0.1.4",
-      "jekyll-titles-from-headings"  => "0.4.0",
+      "jekyll-titles-from-headings"  => "0.5.0",
 
       # Pin listen because it's broken on 2.1 & that's what we recommend.
       # https://github.com/guard/listen/pull/371


### PR DESCRIPTION
This PR bumps Jekyll Relative Links, Jekyll Optional Front Matter, Jekyll README index and Jekyll Titles from headings to their latest versions.

Thanks to @qwtel, across the board the changes are:

* Added opt-in support for collections
* Added the ability to disable the plugin entirely via a config flag
* Added opt-in support for removing original files (optional front matter, readme index)
* Added opt-in support for removing original titles (titles from headings)

Releases:

* https://github.com/benbalter/jekyll-relative-links/releases/tag/v0.5.0
* https://github.com/benbalter/jekyll-optional-front-matter/releases/tag/v0.3.0
* https://github.com/benbalter/jekyll-readme-index/releases/tag/v0.2.0
* https://github.com/benbalter/jekyll-titles-from-headings/releases/tag/v0.5.0
