### PR TITLE
Whitelist jekyll-octicons for everyone

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,6 @@
 source "https://rubygems.org"
 
 gemspec
+
+# Whitelisted plugins not included in runtime dependencies.
+gem "jekyll-octicons"

--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -35,6 +35,7 @@ module GitHubPages
       jekyll-default-layout
       jekyll-titles-from-headings
       jekyll-include-cache
+      jekyll-octicons
     ).freeze
 
     # Plugins only allowed locally

--- a/spec/fixtures/Gemfile
+++ b/spec/fixtures/Gemfile
@@ -4,3 +4,6 @@ source "https://rubygems.org"
 
 gem "github-pages", :group => :jekyll_plugins, :path => "../../"
 gem "jekyll_test_plugin_malicious"
+
+# Whitelisted plugins not included in runtime dependencies.
+gem "jekyll-octicons", :group => :jekyll_plugins

--- a/spec/fixtures/_config.yml
+++ b/spec/fixtures/_config.yml
@@ -4,6 +4,7 @@ gems:
   - jekyll-sitemap
   - jekyll-redirect-from
   - jekyll-feed
+  - jekyll-octicons
   - jekyll-paginate
   - jekyll-seo-tag
   - jekyll-avatar

--- a/spec/fixtures/jekyll-octicons.md
+++ b/spec/fixtures/jekyll-octicons.md
@@ -1,0 +1,4 @@
+---
+---
+
+{% octicon alert height:32 class:"right left" aria-label:hi %}

--- a/spec/github-pages/integration_spec.rb
+++ b/spec/github-pages/integration_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Pages Gem Integration spec" do
     {
       "BUNDLE_GEMFILE" => "#{source}/Gemfile",
       "JEKYLL_ENV"     => "development",
+      "DISABLE_WHITELIST" => "", # Do not disable the whitelist.
     }
   end
 
@@ -29,7 +30,7 @@ RSpec.describe "Pages Gem Integration spec" do
     Dir.chdir(source) do
       bundle_output, status = Open3.capture2e env, %w(bundle install)
       raise StandardError, bundle_output if status.exitstatus != 0
-      cmd = %w(bundle exec jekyll build --verbose)
+      cmd = %w(bundle exec jekyll build --verbose --trace)
       cmd = cmd.concat ["--source", source, "--destination", destination]
       build_output, status = Open3.capture2e env, *cmd
       raise StandardError, bundle_output + build_output if status.exitstatus != 0

--- a/spec/github-pages/integration_spec.rb
+++ b/spec/github-pages/integration_spec.rb
@@ -222,4 +222,12 @@ RSpec.describe "Pages Gem Integration spec" do
       expect(contents).to match('<div class="container-lg px-3 my-5 markdown-body">')
     end
   end
+
+  context "jekyll-octicons" do
+    it "plops in the octicon" do
+      expect(contents).to match('<svg height="32"')
+      expect(contents).to match('class="octicon octicon-alert right left"')
+      expect(contents).to match('aria-label="hi"')
+    end
+  end
 end

--- a/spec/github-pages/plugins_spec.rb
+++ b/spec/github-pages/plugins_spec.rb
@@ -15,6 +15,7 @@ describe(GitHubPages::Plugins) do
     GitHubPages::Plugins::PLUGIN_WHITELIST.each do |plugin|
       it "versions the #{plugin} plugin" do
         next if plugin == "jekyll-include-cache"
+        next if plugin == "jekyll-octicons" # TODO: we should expose the version for these
         expect(GitHubPages::Dependencies::VERSIONS.keys).to include(plugin)
       end
     end


### PR DESCRIPTION
Whitelists [jekyll-octicons](https://github.com/primer/jekyll-octicons) for everyone.

But do not include as a runtime dependency because not everyone will find it useful.