### PR TITLE
[beta] Jekyll Remote Theme

### DIFF
--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -36,6 +36,7 @@ module GitHubPages
       jekyll-titles-from-headings
       jekyll-include-cache
       jekyll-octicons
+      jekyll-remote-theme
     ).freeze
 
     # Plugins only allowed locally

--- a/spec/github-pages/plugins_spec.rb
+++ b/spec/github-pages/plugins_spec.rb
@@ -16,6 +16,7 @@ describe(GitHubPages::Plugins) do
       it "versions the #{plugin} plugin" do
         next if plugin == "jekyll-include-cache"
         next if plugin == "jekyll-octicons" # TODO: we should expose the version for these
+        next if plugin == "jekyll-remote-theme"
         expect(GitHubPages::Dependencies::VERSIONS.keys).to include(plugin)
       end
     end


### PR DESCRIPTION
Once merged and released, this pull request adds [Jekyll Remote Theme](https://github.com/benbalter/jekyll-remote-theme) to the plugin whitelist making it available for use with GitHub Pages. 

Please note that at this time, GitHub does not provide support for Jekyll Remote Theme. It may be buggy or not work at all. If you choose to test the plugin, you can provide feedback by [opening an issue or pull request in the open source Jekyll Remote Theme repository](https://github.com/benbalter/jekyll-remote-theme/issues).

If you would like to test Jekyll Remote Themes during the beta period, you can do so by adding the following to your site's `_config.yml`:

```yml
remote_theme: owner/repository
```

Where `owner` and `repository` are the path to a GitHub-hosted, Gem-based theme (e.g., `benbalter/retlab`).

Additionally, to preview your site locally, you must also:

1. Add the following to your site's Gemfile:

    ```ruby
    gem 'jekyll-remote-theme'
   ```

2. Add the following to your site's config:

    ```yml
   gems:
      - jekyll-remote-theme
    ```
For more information, please see [the Jekyll Remote Theme documentation](https://github.com/benbalter/jekyll-remote-theme).

