### PR TITLE
Make Jekyll Remote Theme enabled by default

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -28,6 +28,7 @@ module GitHubPages
       "jekyll-seo-tag"         => "2.3.0",
       "jekyll-github-metadata" => "2.9.3",
       "jekyll-avatar"          => "0.5.0",
+      "jekyll-remote-theme"    => "0.2.3",
 
       # Plugins to match GitHub.com Markdown
       "jemoji"                       => "0.8.1",

--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -14,6 +14,7 @@ module GitHubPages
       jekyll-readme-index
       jekyll-default-layout
       jekyll-titles-from-headings
+      jekyll-remote-theme
     ).freeze
 
     # Plugins allowed by GitHub Pages

--- a/spec/fixtures/_config_with_remote_theme.yml
+++ b/spec/fixtures/_config_with_remote_theme.yml
@@ -1,0 +1,19 @@
+some_key: some_value
+safe: false
+gems:
+  - jekyll-sitemap
+  - jekyll-redirect-from
+  - jekyll-feed
+  - jekyll-octicons
+  - jekyll-paginate
+  - jekyll-seo-tag
+  - jekyll-avatar
+  - jemoji
+  - jekyll-mentions
+  - jekyll_test_plugin_malicious
+quiet: false
+paginate: 5
+github:
+  source:
+    branch: gh-pages
+remote_theme: pages-themes/cayman

--- a/spec/fixtures/jekyll-remote-theme.md
+++ b/spec/fixtures/jekyll-remote-theme.md
@@ -1,0 +1,7 @@
+---
+layout: default
+---
+
+remote_theme: {{ site.remote_theme }}
+
+theme: {{ site.theme }}

--- a/spec/github-pages/integration_spec.rb
+++ b/spec/github-pages/integration_spec.rb
@@ -21,215 +21,248 @@ RSpec.describe "Pages Gem Integration spec" do
     }
   end
 
-  let(:file) { "#{self.class.description}.html" }
-  let(:path) { destination_file file }
-  let(:contents) { File.read path }
+  def build(additional_flags = nil)
+    Dir.chdir(source) do
+      cmd = %w(bundle exec jekyll build --verbose --trace)
+      cmd = cmd.concat ["--source", source, "--destination", destination]
+      cmd = cmd.concat(additional_flags) if additional_flags
+      build_output, status = Open3.capture2e env, *cmd
+      raise StandardError, build_output if status.exitstatus != 0
+    end
+  end
 
-  before(:all) do
-    FileUtils.rm_rf(destination)
+  def bundle_install
     Dir.chdir(source) do
       bundle_output, status = Open3.capture2e env, %w(bundle install)
       raise StandardError, bundle_output if status.exitstatus != 0
-      cmd = %w(bundle exec jekyll build --verbose --trace)
-      cmd = cmd.concat ["--source", source, "--destination", destination]
-      build_output, status = Open3.capture2e env, *cmd
-      raise StandardError, bundle_output + build_output if status.exitstatus != 0
-    end
-  end
-  after(:all) { FileUtils.rm_rf(destination) }
-
-  it "tests all dependencies" do
-    contents = File.read(__FILE__)
-    contexts = contents.scan(/context \"(.*?)\"/)
-    missing = GitHubPages::Dependencies::VERSIONS.keys - contexts.flatten
-    missing -= %w(listen activesupport github-pages-health-check)
-    msg = "The following dependencies are missing integration tests: #{missing.join(", ")}"
-    expect(missing).to be_empty, msg
-  end
-
-  context "jekyll" do
-    it "builds" do
-      expect(path).to be_an_existing_file
     end
   end
 
-  context "jekyll-sass-converter" do
-    let(:file) { "jekyll-sass-converter.css" }
-
-    it "Renders SCSS" do
-      expect(path).to be_an_existing_file
-      expect(contents).to match("body { color: #333; }")
-    end
+  def rm_destination
+    FileUtils.rm_rf(destination)
   end
 
-  context "kramdown" do
-    it "converts markdown to HTML" do
-      expect(contents).to match('<h1 id="test">Test</h1>')
+  let(:file) { "#{self.class.description}.html" }
+  let(:path) { destination_file file }
+  let(:contents) { File.read path }
+  after(:all) { rm_destination }
+
+  context "fixture site with default config" do
+    before(:all) do
+      rm_destination
+      bundle_install
+      build
     end
-  end
 
-  context "liquid" do
-    it "renders liquid templates" do
-      expect(contents).to match("Value of foo: bar")
+    it "tests all dependencies" do
+      contents = File.read(__FILE__)
+      contexts = contents.scan(/context \"(.*?)\"/)
+      missing = GitHubPages::Dependencies::VERSIONS.keys - contexts.flatten
+      missing -= %w(listen activesupport github-pages-health-check)
+      msg = "The following dependencies are missing integration tests: #{missing.join(", ")}"
+      expect(missing).to be_empty, msg
     end
-  end
 
-  context "rouge" do
-    it "syntax highlights" do
-      expected = '<div class="language-ruby highlighter-rouge">'.dup
-      expected << '<div class="highlight"><pre class="highlight">'
-      expected << '<code><span class="nb">'
-      expected << 'puts</span> <span class="s2">"hello world"'
-      expect(contents).to match(expected)
-    end
-  end
-
-  context "jekyll-redirect-from" do
-    context "redirect_from" do
-      let(:file) { "redirect/index.html" }
-
-      it "redirects from" do
+    context "jekyll" do
+      it "builds" do
         expect(path).to be_an_existing_file
-        expected = '<meta http-equiv="refresh" content="0; url=/redirect_from.html">'
+      end
+    end
+
+    context "jekyll-sass-converter" do
+      let(:file) { "jekyll-sass-converter.css" }
+
+      it "Renders SCSS" do
+        expect(path).to be_an_existing_file
+        expect(contents).to match("body { color: #333; }")
+      end
+    end
+
+    context "kramdown" do
+      it "converts markdown to HTML" do
+        expect(contents).to match('<h1 id="test">Test</h1>')
+      end
+    end
+
+    context "liquid" do
+      it "renders liquid templates" do
+        expect(contents).to match("Value of foo: bar")
+      end
+    end
+
+    context "rouge" do
+      it "syntax highlights" do
+        expected = '<div class="language-ruby highlighter-rouge">'.dup
+        expected << '<div class="highlight"><pre class="highlight">'
+        expected << '<code><span class="nb">'
+        expected << 'puts</span> <span class="s2">"hello world"'
         expect(contents).to match(expected)
       end
     end
 
-    context "redirect_to" do
-      it "redirects to" do
+    context "jekyll-redirect-from" do
+      context "redirect_from" do
+        let(:file) { "redirect/index.html" }
+
+        it "redirects from" do
+          expect(path).to be_an_existing_file
+          expected = '<meta http-equiv="refresh" content="0; url=/redirect_from.html">'
+          expect(contents).to match(expected)
+        end
+      end
+
+      context "redirect_to" do
+        it "redirects to" do
+          expect(path).to be_an_existing_file
+          expected = '<meta http-equiv="refresh" content="0; url=/someplace-else/">'
+          expect(contents).to match(expected)
+        end
+      end
+    end
+
+    context "jekyll-sitemap" do
+      let(:file) { "sitemap.xml" }
+
+      it "builds the sitemap" do
         expect(path).to be_an_existing_file
-        expected = '<meta http-equiv="refresh" content="0; url=/someplace-else/">'
+        expect(contents).to match("<loc>/jekyll.html</loc>")
+      end
+    end
+
+    context "jekyll-feed" do
+      let(:file) { "feed.xml" }
+
+      it "builds the feed" do
+        expect(path).to be_an_existing_file
+        expected = '<title type="html">Test</title><link href="/2017/01/10/test.html"'
         expect(contents).to match(expected)
+      end
+    end
+
+    context "jekyll-gist" do
+      it "creates the script tag" do
+        expected = '<script src="https://gist.github.com/parkr/c08ee0f2726fd0e3909d.js">'
+        expect(contents).to match(expected)
+      end
+    end
+
+    context "jekyll-paginate" do
+      let(:file) { "index.html" }
+
+      it "paginates" do
+        expect(contents).to match("Page: 1")
+        expect(contents).to match("Total Pages: 1")
+      end
+    end
+
+    context "jekyll-coffeescript" do
+      let(:file) { "jekyll-coffeescript.js" }
+
+      it "converts to JS" do
+        expect(path).to be_an_existing_file
+        expected = Regexp.escape 'console.log("hello world");'
+        expect(contents).to match(expected)
+      end
+    end
+
+    context "jekyll-seo-tag" do
+      it "outputs the tag" do
+        expect(contents).to match("<title>Jekyll SEO Tag")
+      end
+    end
+
+    context "jekyll-github-metadata" do
+      it "builds the site.github namespace" do
+        expect(contents).to match("Branch: gh-pages")
+      end
+    end
+
+    context "jekyll-avatar" do
+      it "renders the avatar" do
+        expected = %r{https://avatars\d\.githubusercontent\.com/hubot\?v=3&s=40}
+        expect(contents).to match(expected)
+      end
+    end
+
+    context "jemoji" do
+      it "renders emoji" do
+        expect(contents).to match('<img class="emoji" title=":tada:" alt=":tada:"')
+      end
+    end
+
+    context "jekyll-mentions" do
+      it "renderse mentions" do
+        expect(contents).to match('<a href="https://github.com/jekyll" class="user-mention">@jekyll</a>')
+      end
+    end
+
+    context "jekyll-relative-links" do
+      it "converts relative links" do
+        expect(contents).to match('<a href="/jekyll.html">Jekyll</a>')
+      end
+    end
+
+    context "jekyll-optional-front-matter" do
+      it "renders pages without front matter" do
+        expect(path).to be_an_existing_file
+        expected = '<h1 id="file-without-front-matter">File without front matter</h1>'
+        expect(contents).to match(expected)
+      end
+    end
+
+    context "jekyll-titles-from-headings" do
+      it "pulls titles from headings" do
+        expect(contents).to match("The page title is “First heading”")
+      end
+    end
+
+    context "jekyll-default-layout" do
+      it "sets the default layout" do
+        expect(contents).to match("This page’s layout is “page”")
+      end
+    end
+
+    context "jekyll-readme-index" do
+      let(:file) { "jekyll-readme-index/index.html" }
+
+      it "uses the README as the index" do
+        expect(path).to be_an_existing_file
+        expect(contents).to match("README")
+      end
+    end
+
+    context "jekyll-theme-primer" do
+      it "sets the theme" do
+        expect(contents).to match("Theme: jekyll-theme-primer")
+      end
+
+      it "uses the theme" do
+        expect(contents).to match('<div class="container-lg px-3 my-5 markdown-body">')
+      end
+    end
+
+    context "jekyll-octicons" do
+      it "plops in the octicon" do
+        expect(contents).to match('<svg height="32"')
+        expect(contents).to match('class="octicon octicon-alert right left"')
+        expect(contents).to match('aria-label="hi"')
       end
     end
   end
 
-  context "jekyll-sitemap" do
-    let(:file) { "sitemap.xml" }
-
-    it "builds the sitemap" do
-      expect(path).to be_an_existing_file
-      expect(contents).to match("<loc>/jekyll.html</loc>")
-    end
-  end
-
-  context "jekyll-feed" do
-    let(:file) { "feed.xml" }
-
-    it "builds the feed" do
-      expect(path).to be_an_existing_file
-      expected = '<title type="html">Test</title><link href="/2017/01/10/test.html"'
-      expect(contents).to match(expected)
-    end
-  end
-
-  context "jekyll-gist" do
-    it "creates the script tag" do
-      expected = '<script src="https://gist.github.com/parkr/c08ee0f2726fd0e3909d.js">'
-      expect(contents).to match(expected)
-    end
-  end
-
-  context "jekyll-paginate" do
-    let(:file) { "index.html" }
-
-    it "paginates" do
-      expect(contents).to match("Page: 1")
-      expect(contents).to match("Total Pages: 1")
-    end
-  end
-
-  context "jekyll-coffeescript" do
-    let(:file) { "jekyll-coffeescript.js" }
-
-    it "converts to JS" do
-      expect(path).to be_an_existing_file
-      expected = Regexp.escape 'console.log("hello world");'
-      expect(contents).to match(expected)
-    end
-  end
-
-  context "jekyll-seo-tag" do
-    it "outputs the tag" do
-      expect(contents).to match("<title>Jekyll SEO Tag")
-    end
-  end
-
-  context "jekyll-github-metadata" do
-    it "builds the site.github namespace" do
-      expect(contents).to match("Branch: gh-pages")
-    end
-  end
-
-  context "jekyll-avatar" do
-    it "renders the avatar" do
-      expected = %r{https://avatars\d\.githubusercontent\.com/hubot\?v=3&s=40}
-      expect(contents).to match(expected)
-    end
-  end
-
-  context "jemoji" do
-    it "renders emoji" do
-      expect(contents).to match('<img class="emoji" title=":tada:" alt=":tada:"')
-    end
-  end
-
-  context "jekyll-mentions" do
-    it "renderse mentions" do
-      expect(contents).to match('<a href="https://github.com/jekyll" class="user-mention">@jekyll</a>')
-    end
-  end
-
-  context "jekyll-relative-links" do
-    it "converts relative links" do
-      expect(contents).to match('<a href="/jekyll.html">Jekyll</a>')
-    end
-  end
-
-  context "jekyll-optional-front-matter" do
-    it "renders pages without front matter" do
-      expect(path).to be_an_existing_file
-      expected = '<h1 id="file-without-front-matter">File without front matter</h1>'
-      expect(contents).to match(expected)
-    end
-  end
-
-  context "jekyll-titles-from-headings" do
-    it "pulls titles from headings" do
-      expect(contents).to match("The page title is “First heading”")
-    end
-  end
-
-  context "jekyll-default-layout" do
-    it "sets the default layout" do
-      expect(contents).to match("This page’s layout is “page”")
-    end
-  end
-
-  context "jekyll-readme-index" do
-    let(:file) { "jekyll-readme-index/index.html" }
-
-    it "uses the README as the index" do
-      expect(path).to be_an_existing_file
-      expect(contents).to match("README")
-    end
-  end
-
-  context "jekyll-theme-primer" do
-    it "sets the theme" do
-      expect(contents).to match("Theme: jekyll-theme-primer")
+  context "fixture site with remote theme config" do
+    before(:all) do
+      rm_destination
+      bundle_install
+      build(["--config", "_config_with_remote_theme.yml"])
     end
 
-    it "uses the theme" do
-      expect(contents).to match('<div class="container-lg px-3 my-5 markdown-body">')
-    end
-  end
-
-  context "jekyll-octicons" do
-    it "plops in the octicon" do
-      expect(contents).to match('<svg height="32"')
-      expect(contents).to match('class="octicon octicon-alert right left"')
-      expect(contents).to match('aria-label="hi"')
+    context "jekyll-remote-theme" do
+      it "builds with a remote theme" do
+        expect(contents).to match("remote_theme: pages-themes/cayman")
+        expect(contents).to match("theme: cayman")
+        expect(contents).to match('<h1 class="project-name">pages-gem</h1>')
+      end
     end
   end
 end

--- a/spec/github-pages/plugins_spec.rb
+++ b/spec/github-pages/plugins_spec.rb
@@ -16,7 +16,6 @@ describe(GitHubPages::Plugins) do
       it "versions the #{plugin} plugin" do
         next if plugin == "jekyll-include-cache"
         next if plugin == "jekyll-octicons" # TODO: we should expose the version for these
-        next if plugin == "jekyll-remote-theme"
         expect(GitHubPages::Dependencies::VERSIONS.keys).to include(plugin)
       end
     end


### PR DESCRIPTION
A follow up to https://github.com/github/pages-gem/pull/495, this PR versions Jekyll Remote Theme and makes it enabled by default (but will have no effect unless the key `remote_theme` is set in the user's config).

**Edit**: Cleaner diff: https://github.com/github/pages-gem/pull/499/files?w=1