### PR TITLE
Configure GFM per Pages

### DIFF
--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -121,17 +121,20 @@ module GitHubPages
 
       # Ensure we're using Kramdown or GFM.  Force to Kramdown if
       # neither of these.
+      #
+      # This can get called multiply on the same config, so try to
+      # be idempotentish.
       def restrict_and_config_markdown_processor(config)
         config["markdown"] = "kramdown" unless \
-          %w(kramdown gfm).include?(config["markdown"].to_s.downcase)
+          %w(kramdown gfm commonmarkghpages).include?(config["markdown"].to_s.downcase)
 
-        if config["markdown"].to_s.casecmp("gfm").zero?
-          config["markdown"] = "CommonMarkGhPages"
-          config["commonmark"] = {
-            "extensions" => %w(table strikethrough autolink tagfilter),
-            "options" => %w(footnotes),
-          }
-        end
+        return unless config["markdown"].to_s.casecmp("gfm").zero?
+
+        config["markdown"] = "CommonMarkGhPages"
+        config["commonmark"] = {
+          "extensions" => %w(table strikethrough autolink tagfilter),
+          "options" => %w(footnotes),
+        }
       end
 
       # Set the site's configuration. Implemented as an `after_reset` hook.

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -103,7 +103,7 @@ module GitHubPages
         # Merge overwrites into user config
         config = Jekyll::Utils.deep_merge_hashes config, OVERRIDES
 
-        restrict_markdown_processor(config)
+        restrict_and_config_markdown_processor(config)
 
         # Ensure we have those gems we want.
         config["plugins"] = Array(config["plugins"]) | DEFAULT_PLUGINS
@@ -121,9 +121,17 @@ module GitHubPages
 
       # Ensure we're using Kramdown or GFM.  Force to Kramdown if
       # neither of these.
-      def restrict_markdown_processor(config)
+      def restrict_and_config_markdown_processor(config)
         config["markdown"] = "kramdown" unless \
           %w(kramdown gfm).include?(config["markdown"].to_s.downcase)
+
+        if config["markdown"].to_s.casecmp("gfm").zero?
+          config["markdown"] = "CommonMarkGhPages"
+          config["commonmark"] = {
+            "extensions" => %w(table strikethrough autolink tagfilter),
+            "options" => %w(footnotes),
+          }
+        end
       end
 
       # Set the site's configuration. Implemented as an `after_reset` hook.

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -12,6 +12,7 @@ module GitHubPages
 
       # Converters
       "kramdown"                  => "1.14.0",
+      "jekyll-commonmark-ghpages" => "0.1.3",
 
       # Misc
       "liquid"                    => "4.0.0",

--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -6,6 +6,7 @@ module GitHubPages
     # Plugins which are activated by default
     DEFAULT_PLUGINS = %w(
       jekyll-coffeescript
+      jekyll-commonmark-ghpages
       jekyll-gist
       jekyll-github-metadata
       jekyll-paginate
@@ -20,6 +21,7 @@ module GitHubPages
     # Plugins allowed by GitHub Pages
     PLUGIN_WHITELIST = %w(
       jekyll-coffeescript
+      jekyll-commonmark-ghpages
       jekyll-feed
       jekyll-gist
       jekyll-github-metadata

--- a/spec/fixtures/_config_with_gfm.yml
+++ b/spec/fixtures/_config_with_gfm.yml
@@ -1,0 +1,19 @@
+markdown: GFM
+some_key: some_value
+safe: false
+gems:
+  - jekyll-sitemap
+  - jekyll-redirect-from
+  - jekyll-feed
+  - jekyll-octicons
+  - jekyll-paginate
+  - jekyll-seo-tag
+  - jekyll-avatar
+  - jemoji
+  - jekyll-mentions
+  - jekyll_test_plugin_malicious
+quiet: false
+paginate: 5
+github:
+  source:
+    branch: gh-pages

--- a/spec/fixtures/jekyll-commonmark-ghpages.md
+++ b/spec/fixtures/jekyll-commonmark-ghpages.md
@@ -1,0 +1,5 @@
+---
+layout: default
+---
+
+markdown: {{ site.markdown }}

--- a/spec/github-pages/configuration_spec.rb
+++ b/spec/github-pages/configuration_spec.rb
@@ -71,8 +71,12 @@ describe(GitHubPages::Configuration) do
           Jekyll::Site.new(config)
         end
 
-        it "keeps the setting" do
-          expect(effective_config["markdown"]).to eql("GFM")
+        it "configures CommonMarkGhPages" do
+          expect(effective_config["markdown"]).to eql("CommonMarkGhPages")
+          expect(effective_config["commonmark"]).to eql(
+            "extensions" => %w(table strikethrough autolink tagfilter),
+            "options" => %w(footnotes)
+          )
         end
       end
 

--- a/spec/github-pages/integration_spec.rb
+++ b/spec/github-pages/integration_spec.rb
@@ -165,10 +165,6 @@ RSpec.describe "Pages Gem Integration spec" do
       end
     end
 
-    context "jekyll-commonmark-ghpages" do
-      # noop: this is tested by other things
-    end
-
     context "jekyll-seo-tag" do
       it "outputs the tag" do
         expect(contents).to match("<title>Jekyll SEO Tag")
@@ -267,6 +263,18 @@ RSpec.describe "Pages Gem Integration spec" do
         expect(contents).to match("theme: cayman")
         expect(contents).to match('<h1 class="project-name">pages-gem</h1>')
       end
+    end
+  end
+
+  context "jekyll-commonmark-ghpages" do
+    before(:all) do
+      rm_destination
+      bundle_install
+      build(["--config", "_config_with_gfm.yml"])
+    end
+
+    it "builds with GFM" do
+      expect(contents).to match("markdown: CommonMarkGhPages")
     end
   end
 end

--- a/spec/github-pages/integration_spec.rb
+++ b/spec/github-pages/integration_spec.rb
@@ -165,6 +165,10 @@ RSpec.describe "Pages Gem Integration spec" do
       end
     end
 
+    context "jekyll-commonmark-ghpages" do
+      # noop: this is tested by other things
+    end
+
     context "jekyll-seo-tag" do
       it "outputs the tag" do
         expect(contents).to match("<title>Jekyll SEO Tag")


### PR DESCRIPTION
Configure a `markdown: GFM`-configured (!) Jekyll instance like GitHub Pages does. A local clone of a Jekyll site using the `github-pages` gem can just use `markdown: GFM` in their `_config.yml` and it'll work locally exactly like it does in Pages.

A lot of this is duplicated in the inmate image; after merging this we can remove the special-casing there, such that this is what is actually controlling what happens there!

TODO:

- [x] an actual integration test for `GFM` parser

/cc @github/pages 