### PR TITLE
script/bump: enforce being on 'master' branch for releases.

### DIFF
--- a/script/bump
+++ b/script/bump
@@ -1,5 +1,10 @@
 #!/bin/bash -ex
 
+(git branch | grep -q '* master') || {
+  echo "Only release from the master branch."
+  exit 1
+}
+
 VERSION_FILE="./lib/github-pages/version.rb"
 OLD_VERSION=$(curl "https://rubygems.org/api/v1/versions/github-pages/latest.json" | jq -r .version)
 NEW_VERSION=$(expr $OLD_VERSION + 1)

--- a/script/bump
+++ b/script/bump
@@ -1,6 +1,8 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
-(git branch | grep -q '* master') || {
+set -e
+
+(git symbolic-ref HEAD | grep -q 'refs/heads/master') || {
   echo "Only release from the master branch."
   exit 1
 }

--- a/script/bump
+++ b/script/bump
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
This partially reverts https://github.com/github/pages-gem/commit/f2b8252c771f12eee4955fdb2b960a69f251f2a0#diff-f9484f4b1a3a5eb061c5fe9c4d5cc7e2L3

Somehow this got deleted (no explanation in commit message), but I think it's important and valid so I propose we keep it.