### PR TITLE
Bump kramdown :gem: to 1.16.2

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -11,7 +11,7 @@ module GitHubPages
       "jekyll-sass-converter"     => "1.5.0",
 
       # Converters
-      "kramdown"                  => "1.14.0",
+      "kramdown"                  => "1.16.2",
       "jekyll-commonmark-ghpages" => "0.1.3",
 
       # Misc


### PR DESCRIPTION
Kramdown 1.16 includes GFM quirk `no_auto_typographic
for disabling typographic conversions, which is usable to
fix issues like https://github.com/gettalong/kramdown/issues/459

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>