### PR TITLE
Constrain minimum Nokogiri and Rubocop versions

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -26,9 +26,10 @@ Gem::Specification.new do |s|
 
   s.add_dependency("mercenary", "~> 0.3")
   s.add_dependency("terminal-table", "~> 1.4")
+  s.add_dependency("nokogiri", ">= 1.8.1", "< 2.0") #CVE-2017-9050
   s.add_development_dependency("rspec", "~> 3.3")
   s.add_development_dependency("rainbow", "~> 2.1.0")
   s.add_development_dependency("pry", "~> 0.10")
   s.add_development_dependency("jekyll_test_plugin_malicious", "~> 0.2")
-  s.add_development_dependency("rubocop", "~> 0.4")
+  s.add_development_dependency("rubocop", ">= 0.48.1", "< 5.0") #CVE-2017-8418
 end

--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -26,10 +26,10 @@ Gem::Specification.new do |s|
 
   s.add_dependency("mercenary", "~> 0.3")
   s.add_dependency("terminal-table", "~> 1.4")
-  s.add_dependency("nokogiri", ">= 1.8.1", "< 2.0") #CVE-2017-9050
+  s.add_dependency("nokogiri", ">= 1.8.1", "< 2.0") # CVE-2017-9050
   s.add_development_dependency("rspec", "~> 3.3")
   s.add_development_dependency("rainbow", "~> 2.1.0")
   s.add_development_dependency("pry", "~> 0.10")
   s.add_development_dependency("jekyll_test_plugin_malicious", "~> 0.2")
-  s.add_development_dependency("rubocop", ">= 0.48.1", "< 5.0") #CVE-2017-8418
+  s.add_development_dependency("rubocop", ">= 0.48.1", "< 5.0") # CVE-2017-8418
 end


### PR DESCRIPTION
While we previously did not constrain the minimum Nokogiri or Rubocop versions, meaning a user could run `bundle update` to update to the latest version, this PR sets a minimum required version to remove potential vulnerability warnings from dependent repositories.

Fixes https://github.com/github/pages-gem/issues/522.