### PR TITLE
Bump jekyll 💎 to v3.7.2 and jekyll-sitemap 💎 to v1.2.0

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -21,7 +21,7 @@ module GitHubPages
 
       # Plugins
       "jekyll-redirect-from"   => "0.12.1",
-      "jekyll-sitemap"         => "1.1.1",
+      "jekyll-sitemap"         => "1.2.0",
       "jekyll-feed"            => "0.9.2",
       "jekyll-gist"            => "1.4.1",
       "jekyll-paginate"        => "1.1.0",

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -7,7 +7,7 @@ module GitHubPages
   class Dependencies
     VERSIONS = {
       # Jekyll
-      "jekyll"                    => "3.6.2",
+      "jekyll"                    => "3.7.2",
       "jekyll-sass-converter"     => "1.5.0",
 
       # Converters


### PR DESCRIPTION
Addresses #524 and the following issue for `jekyll-sitemap` which rendered it unusable for anyone whose site hosted binary files: https://github.com/jekyll/jekyll-sitemap/issues/180