### PR TITLE
bump jekyll-commonmark-ghpages

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -12,7 +12,7 @@ module GitHubPages
 
       # Converters
       "kramdown"                  => "1.16.2",
-      "jekyll-commonmark-ghpages" => "0.1.3",
+      "jekyll-commonmark-ghpages" => "0.1.4",
 
       # Misc
       "liquid"                    => "4.0.0",


### PR DESCRIPTION
Fixes a `frozen_string_literal` error some pages builds were hitting.

/cc @benbalter @parkr 