### PR TITLE
update jekyll-commonmark-ghpages to 0.1.5

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -12,7 +12,7 @@ module GitHubPages
 
       # Converters
       "kramdown"                  => "1.16.2",
-      "jekyll-commonmark-ghpages" => "0.1.4",
+      "jekyll-commonmark-ghpages" => "0.1.5",
 
       # Misc
       "liquid"                    => "4.0.0",


### PR DESCRIPTION
A fix was made to address the issue in https://github.com/github/jekyll-commonmark-ghpages/pull/4 (syntax highlighting had `\r?\n` replaced with `<br data-jekyll-commonmark-ghpages>` in non-CommonMark-rendered pages).

/cc @github/pages 