### PR TITLE
Adding jekyll-twitter-plugin to plugins whitelist

### DIFF
--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -39,6 +39,7 @@ module GitHubPages
       jekyll-include-cache
       jekyll-octicons
       jekyll-remote-theme
+      jekyll-twitter-plugin
     ).freeze
 
     # Plugins only allowed locally


### PR DESCRIPTION
Hi!

## Overview
Adding the [jekyll twitter plugin](https://github.com/rob-murray/jekyll-twitter-plugin) to the plugin whitelist.

Allow user to display twitter timelines on gh-pages.

## Usages
Add the jekyll-twitter-plugin to your site `_config.yml` file for Jekyll to import the plugin as a gem.
```yaml
plugins: ['jekyll-twitter-plugin']
```

Example for timeline of the **jekyllrb** user with a maximum of 5 Tweets and with a width of 500px:
```markdown
{% twitter https://twitter.com/jekyllrb maxwidth=500 limit=5 %}
```