### PR TITLE
Allow the kramdown math engine to be overridden

### DIFF
--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -22,6 +22,7 @@ module GitHubPages
         "input"     => "GFM",
         "hard_wrap" => false,
         "gfm_quirks" => "paragraph_end",
+        "math_engine" => "mathjax",
       },
       "exclude" => ["CNAME"],
     }.freeze
@@ -51,7 +52,6 @@ module GitHubPages
       "highlighter" => "rouge",
       "kramdown"    => {
         "template"           => "",
-        "math_engine"        => "mathjax",
         "syntax_highlighter" => "rouge",
       },
       "gist"        => {


### PR DESCRIPTION
This will allow the use of the nil math engine in kramdown, which
provides a saner default for templates that don't want mathjax but want
a safe fallback for when javascript is disabled.

From the history of this repo, the math engine used to be changeable up until 2 years ago when kramdown became the primary/only markdown engine. I have not checked if the version of kramdown used back then even had multiple math engines.