### PR TITLE
Allow theme to be explicitly disabled

### DIFF
--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -101,6 +101,9 @@ module GitHubPages
           .fix_common_issues
           .add_default_collections
 
+        # Allow theme to be explicitly disabled via "theme: null"
+        config["theme"] = user_config["theme"] if user_config.key?("theme")
+
         exclude_cname(config)
 
         # Merge overwrites into user config

--- a/spec/github-pages/configuration_spec.rb
+++ b/spec/github-pages/configuration_spec.rb
@@ -118,6 +118,17 @@ describe(GitHubPages::Configuration) do
         end
       end
 
+      context "with user-specified theme to be null" do
+        let(:site) do
+          config = configuration.merge("theme" => nil)
+          Jekyll::Site.new(config)
+        end
+
+        it "respects null" do
+          expect(site.theme).to be_nil
+        end
+      end
+
       it "plugins don't include jekyll remote theme" do
         expect(effective_config["plugins"]).to_not include("jekyll-remote-theme")
       end


### PR DESCRIPTION
This PR allows theme to be explicitly disabled via `theme: null`.

When a source site contains its theme, files from the default theme `jekyll-theme-primer` will still ends up in the dest site. The most annoying part of this issue (pages-themes/primer#15) is that `assets/css/style.css` from `jekyll-theme-primer` would show up in `site.pages` collection (e.g. `sitemap.xml`). The upstream seems to have no interest in fixing that issue, and I don't really care either as long as I can avoid that buggy theme.

According to [Jekyll::Site.configure_theme](https://github.com/jekyll/jekyll/blob/29dc190fcb41f13dfe9764d1d539a34657d44788/lib/jekyll/site.rb#L435), supposedly a user should be able to disable any theme by having `theme: null` in `_config.yml`. However, due to the way configurations are merged in [GitHubPages::Configuration.effective_config](https://github.com/github/pages-gem/blob/938b95356d0dda654d2323ff7075b38b20ce597b/lib/github-pages/configuration.rb#L100) (eventually the logic in [Jekyll::Utils.deep_merge_hashes](https://github.com/jekyll/jekyll/blob/29dc190fcb41f13dfe9764d1d539a34657d44788/lib/jekyll/utils.rb#L319-L320)), an explicit `theme: null` will still be overrode by `theme: "jekyll-theme-primer"`.

Changing the behavior of `Jekyll::Utils.deep_merge_hashes` on explicit `null` in yaml (or `nil` in ruby) is unrealistic, as it is so fundamental that tons of existing code depend on its current behavior. Thus, the best solution is fixing it the after configuration merging in this repository.

#482 mentioned using a hack of `theme: false`, it works because [Jekyll::Site.configure_theme](https://github.com/jekyll/jekyll/blob/29dc190fcb41f13dfe9764d1d539a34657d44788/lib/jekyll/site.rb#L441-L443) treats a boolean `false` as an invalid value and then fallback to `nil`. This PR is intended to avoid the such hack and properly allow theme to be explicitly disabled.
