### PR TITLE
travis.yml: only build master branches.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ rvm:
   - 2.4
   - 2.5
 
+branches:
+  only:
+    - master
+
 before_install:
   - gem install bundler
 script: "script/cibuild"


### PR DESCRIPTION
This avoid duplicate, unnecessary jobs when creating a PR from a non-fork branch.