### PR TITLE
Bump jekyll-avatar to v0.6.0

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -28,7 +28,7 @@ module GitHubPages
       "jekyll-coffeescript"    => "1.1.1",
       "jekyll-seo-tag"         => "2.4.0",
       "jekyll-github-metadata" => "2.9.4",
-      "jekyll-avatar"          => "0.5.0",
+      "jekyll-avatar"          => "0.6.0",
       "jekyll-remote-theme"    => "0.3.1",
 
       # Plugins to match GitHub.com Markdown


### PR DESCRIPTION
https://github.com/benbalter/jekyll-avatar/releases/tag/v0.6.0

cc @benbalter 