### PR TITLE
Require Ruby 2.3.0 or greater

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@
 # If you disable a check, document why.
 
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
   Exclude:
     - 'bin/**/*'
     - 'script/**/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.2
   - 2.3
   - 2.4
   - 2.5

--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -5,7 +5,7 @@ require File.expand_path("../lib/github-pages/plugins", __FILE__)
 require File.expand_path("../lib/github-pages/version", __FILE__)
 
 Gem::Specification.new do |s|
-  s.required_ruby_version = ">= 2.0.0"
+  s.required_ruby_version = ">= 2.3.0"
 
   s.name                  = "github-pages"
   s.version               = GitHubPages::VERSION


### PR DESCRIPTION
I noticed in https://github.com/github/pages/pull/2086 that jekyll-seo-tag v2.5.0 requires Ruby 2.3 or greater.

As it turns out, Ruby 2.2 is now EOL, and Ruby 2.3 is EOL in March 2019. https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/

In the Jekyll project, it was our general understanding that we would drop support for a minor bump of Ruby only explicitly (i.e. require something higher) in a major version bump of Jekyll. In GitHub Pages, we don't have that same issue, since every version bump is a major version bump.

Generally speaking, supporting an EOL Ruby version is ill-advised. An EOL version doesn't receive security patches, and may have bugs that will never be fixed. By targeting Ruby 2.3 or higher, we can eliminate the likelihood that our users are exposed to any security vulnerabilities that are discovered in Ruby 2.2 and earlier.

Ruby version constraints are heavy-handed, but upgrading is key to keeping our community safe and progressing.