### PR TITLE
changes jekyll-octicons from optional to a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# Whitelisted plugins not included in runtime dependencies.
-gem "jekyll-octicons"

--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -15,6 +15,7 @@ module GitHubPages
       jekyll-readme-index
       jekyll-default-layout
       jekyll-titles-from-headings
+      jekyll-octicons
     ).freeze
 
     # Plugins allowed by GitHub Pages
@@ -37,7 +38,6 @@ module GitHubPages
       jekyll-default-layout
       jekyll-titles-from-headings
       jekyll-include-cache
-      jekyll-octicons
       jekyll-remote-theme
     ).freeze
 

--- a/spec/fixtures/Gemfile
+++ b/spec/fixtures/Gemfile
@@ -4,6 +4,3 @@ source "https://rubygems.org"
 
 gem "github-pages", :group => :jekyll_plugins, :path => "../../"
 gem "jekyll_test_plugin_malicious"
-
-# Whitelisted plugins not included in runtime dependencies.
-gem "jekyll-octicons", :group => :jekyll_plugins


### PR DESCRIPTION
[jekyll-octicons](https://github.com/primer/octicons/tree/master/lib/octicons_jekyll) was whitelisted in https://github.com/github/pages-gem/pull/483/files (which is great!) but would just like to propose that it be made a dependency as well so that [remote themes](https://github.com/benbalter/jekyll-remote-theme) can utilize `{% octicon %}` without users having to know to add `jekyll-octicons` to their `_config.yml` as well. Else less-comfortable users who might be using GitHub's web UI to edit pages (and, in turn, to deploy to GitHub Pages) won't know why their use of the theme is failing, since they won't see `Unknown tag 'octicon' included` since they're not building locally.