### PR TITLE
Add test to indicate Jekyll default excludes are retained

### DIFF
--- a/spec/github-pages/configuration_spec.rb
+++ b/spec/github-pages/configuration_spec.rb
@@ -62,6 +62,10 @@ describe(GitHubPages::Configuration) do
       expect(effective_config["exclude"]).to include("CNAME")
     end
 
+    it "retains Jekyll default excludes" do
+      expect(effective_config["exclude"]).to include(*Jekyll::Configuration::DEFAULTS["exclude"])
+    end
+
     context "markdown processor" do
       context "with no markdown processor set" do
         it "defaults to kramdown" do


### PR DESCRIPTION
This change adds an assertion to indicate that the default Jekyll
exclude configuration is merged into the configuration set by the
pages-gem configuration. The defaults can be seen on the [Jekyll Site]
(https://jekyllrb.com/docs/configuration/default/).

After encountering the same issue described in #589 I looked at whether
the default excludes were preserved by the pages-gem, and was confused
by the difference in the behaviour I observed vs what the code said. So
I wrote this test to indicate that the code really does work as you’d
hope it did.