### PR TITLE
Configuration: read the config files manually to better mimic the production environment

### DIFF
--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -5,10 +5,11 @@ require "jekyll"
 
 # Top-level namespace for all GitHub Pages-related concerns.
 module GitHubPages
-  autoload :Plugins,       "github-pages/plugins"
-  autoload :Configuration, "github-pages/configuration"
-  autoload :Dependencies,  "github-pages/dependencies"
-  autoload :VERSION,       "github-pages/version"
+  autoload :Plugins,             "github-pages/plugins"
+  autoload :Configuration,       "github-pages/configuration"
+  autoload :ConfigurationReader, "github-pages/configuration_reader"
+  autoload :Dependencies,        "github-pages/dependencies"
+  autoload :VERSION,             "github-pages/version"
 
   def self.versions
     Dependencies.versions

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -23,7 +23,7 @@ module GitHubPages
         "hard_wrap" => false,
         "gfm_quirks" => "paragraph_end",
       },
-      "exclude" => Jekyll::Configuration::DEFAULTS["exclude"] + ["CNAME"]
+      "exclude" => Jekyll::Configuration::DEFAULTS["exclude"] + ["CNAME"],
     }.freeze
 
     # User-overwritable defaults used only in production for practical reasons

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -23,7 +23,7 @@ module GitHubPages
         "hard_wrap" => false,
         "gfm_quirks" => "paragraph_end",
       },
-      "exclude" => ["CNAME"],
+      "exclude" => Jekyll::Configuration::DEFAULTS["exclude"] + ["CNAME"]
     }.freeze
 
     # User-overwritable defaults used only in production for practical reasons
@@ -104,8 +104,6 @@ module GitHubPages
         # Allow theme to be explicitly disabled via "theme: null"
         config["theme"] = user_config["theme"] if user_config.key?("theme")
 
-        exclude_cname(config)
-
         # Merge overwrites into user config
         config = Jekyll::Utils.deep_merge_hashes config, OVERRIDES
 
@@ -150,12 +148,6 @@ module GitHubPages
           "extensions" => %w(table strikethrough autolink tagfilter),
           "options" => %w(footnotes),
         }
-      end
-
-      # If the user's 'exclude' config is the default, also exclude the CNAME
-      def exclude_cname(config)
-        return unless config["exclude"].eql? Jekyll::Configuration::DEFAULTS["exclude"]
-        config["exclude"].concat(DEFAULTS["exclude"])
       end
 
       # Requires default plugins and configures whitelist in development

--- a/lib/github-pages/configuration_reader.rb
+++ b/lib/github-pages/configuration_reader.rb
@@ -62,7 +62,8 @@ module GitHubPages
     def fix(config)
       if paginate_invalid?(config)
         Jekyll.logger.warn "Config Warning:", "The `paginate` key must be a" \
-          " positive integer or nil. It's currently set to '#{config["paginate"].inspect}'."
+          " positive integer or nil. It's currently set to " \
+          "'#{config["paginate"].inspect}'."
         config["paginate"] = nil
       end
 

--- a/lib/github-pages/configuration_reader.rb
+++ b/lib/github-pages/configuration_reader.rb
@@ -39,7 +39,7 @@ module GitHubPages
 
     # User config, with common issues fixed & backwards compatibilized
     def user_config
-      @user_config ||= Jekyll::Configuration[raw_user_config] \
+      @user_config ||= fix(Jekyll::Configuration[raw_user_config]) \
         .backwards_compatibilize.add_default_collections
     end
 
@@ -54,6 +54,19 @@ module GitHubPages
       rescue ArgumentError, LoadError
         Jekyll::Configuration.new
       end
+    end
+
+    # Fix issues to prevent Jekyll from doing strange things.
+    # In this case, Configuration#check_maruku aborts the process;
+    # we want to simply overwrite with our kramdown default instead.
+    def fix(config)
+      if config.fetch("markdown", "kramdown").to_s.casecmp("maruku").zero?
+        Jekyll.logger.warn "Configuration:", \
+          "maruku is no longer supported; using kramdown instead."
+        config["markdown"] = "kramdown"
+      end
+
+      config
     end
   end
 end

--- a/lib/github-pages/configuration_reader.rb
+++ b/lib/github-pages/configuration_reader.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module GitHubPages
+  # Reads configuration files.
+  class ConfigurationReader
+
+    # Determine configuration files for a site source and read the file(s).
+    # It should be used in conjunction with GitHubPages::Configuration.
+    # This simply reads the files and merges them.
+    def self.read_for_site(source)
+      read(*configuration_files_for(source))
+    end
+
+    # Read one or more configuration files and merge them such that each subsequent
+    # file's contents overwrites the previous file's contents.
+    def self.read(*filenames)
+      filenames.flatten.each_with_object(Jekyll::Configuration.new) do |filename, config|
+        Jekyll::Utils.deep_merge_hashes!(config, new(filename).read)
+      end
+    end
+
+    def self.configuration_files_for(source)
+      Jekyll::Configuration.new.config_files({"source" => source, "quiet" => true})
+    end
+
+    ##################
+    # Instance methods
+    ##################
+
+    attr_reader :filename
+    def initialize(filename)
+      @filename = filename
+    end
+
+    def read
+      user_config
+    end
+
+    private
+
+    # User config, with common issues fixed & backwards compatibilized
+    def user_config
+      @user_config ||= Jekyll::Configuration[raw_user_config] \
+        .backwards_compatibilize.add_default_collections
+    end
+
+    # User config, before our overrides, used for metrics and warnings
+    def raw_user_config
+      @raw_user_config ||= begin
+        Jekyll::Configuration.new.read_config_file(filename)
+      # Ignore problems parsing the file. Here, they don't matter,
+      # we're just looking for the values that were requested. If
+      # the config file is really busted, the Jekyll build may fail,
+      # and it'll report the error to us and to the site owner.
+      rescue ArgumentError, LoadError
+        Jekyll::Configuration.new
+      end
+    end
+  end
+end

--- a/lib/github-pages/configuration_reader.rb
+++ b/lib/github-pages/configuration_reader.rb
@@ -3,7 +3,6 @@
 module GitHubPages
   # Reads configuration files.
   class ConfigurationReader
-
     # Determine configuration files for a site source and read the file(s).
     # It should be used in conjunction with GitHubPages::Configuration.
     # This simply reads the files and merges them.
@@ -20,7 +19,7 @@ module GitHubPages
     end
 
     def self.configuration_files_for(source)
-      Jekyll::Configuration.new.config_files({"source" => source, "quiet" => true})
+      Jekyll::Configuration.new.config_files("source" => source, "quiet" => true)
     end
 
     ##################

--- a/lib/github-pages/configuration_reader.rb
+++ b/lib/github-pages/configuration_reader.rb
@@ -60,13 +60,26 @@ module GitHubPages
     # In this case, Configuration#check_maruku aborts the process;
     # we want to simply overwrite with our kramdown default instead.
     def fix(config)
-      if config.fetch("markdown", "kramdown").to_s.casecmp("maruku").zero?
-        Jekyll.logger.warn "Configuration:", \
-          "maruku is no longer supported; using kramdown instead."
+      if paginate_invalid?(config)
+        Jekyll.logger.warn "Config Warning:", "The `paginate` key must be a" \
+          " positive integer or nil. It's currently set to '#{config["paginate"].inspect}'."
+        config["paginate"] = nil
+      end
+
+      if config["markdown"].to_s.casecmp("maruku").zero?
+        Jekyll.logger.error "Error:", "Maruku has been removed." \
+          " This build will use kramdown instead."
         config["markdown"] = "kramdown"
       end
 
       config
+    end
+
+    def paginate_invalid?(config)
+      config.key?("paginate") && (
+        !config["paginate"].is_a?(Integer) ||
+        config["paginate"] < 1
+      )
     end
   end
 end

--- a/spec/github-pages/configuration_spec.rb
+++ b/spec/github-pages/configuration_spec.rb
@@ -65,7 +65,6 @@ describe(GitHubPages::Configuration) do
 
     it "sets exclude directive" do
       expect(effective_config["exclude"]).to include("CNAME")
-      expect(effective_config["exclude"]).to include(*Jekyll::Configuration::DEFAULTS["exclude"])
     end
 
     it "retains Jekyll default excludes" do

--- a/spec/github-pages/configuration_spec.rb
+++ b/spec/github-pages/configuration_spec.rb
@@ -11,7 +11,7 @@ describe(GitHubPages::Configuration) do
       "destination" => tmp_dir,
     }
   end
-  let(:override_config){ Hash.new }
+  let(:override_config) { {} }
   let(:user_config) { GitHubPages::ConfigurationReader.read_for_site(test_config["source"]) }
   let(:merged_configuration) do
     # user_config <- test_config <- override_config
@@ -79,7 +79,7 @@ describe(GitHubPages::Configuration) do
       end
 
       context "with GFM set" do
-        let(:override_config) { {"markdown" => "GFM"} }
+        let(:override_config) { { "markdown" => "GFM" } }
 
         it "configures CommonMarkGhPages" do
           expect(effective_config["markdown"]).to eql("CommonMarkGhPages")
@@ -91,7 +91,7 @@ describe(GitHubPages::Configuration) do
       end
 
       context "with some other processor set" do
-        let(:override_config) { {"markdown" => "whatever"} }
+        let(:override_config) { { "markdown" => "whatever" } }
 
         it "overrides to kramdown" do
           expect(effective_config["markdown"]).to eql("kramdown")
@@ -109,7 +109,7 @@ describe(GitHubPages::Configuration) do
       end
 
       context "with a user-specified theme" do
-        let(:override_config) { {"theme" => "jekyll-theme-merlot"} }
+        let(:override_config) { { "theme" => "jekyll-theme-merlot" } }
 
         it "respects the theme" do
           expect(site.theme).to_not be_nil
@@ -119,7 +119,7 @@ describe(GitHubPages::Configuration) do
       end
 
       context "with user-specified theme to be null" do
-        let(:override_config) { {"theme" => nil} }
+        let(:override_config) { { "theme" => nil } }
 
         it "respects null" do
           expect(site.theme).to be_nil
@@ -131,7 +131,7 @@ describe(GitHubPages::Configuration) do
       end
 
       context "with a remote theme" do
-        let(:override_config) { {"remote_theme" => "foo/bar"} }
+        let(:override_config) { { "remote_theme" => "foo/bar" } }
 
         it "plugins include jekyll remote theme" do
           expect(effective_config["plugins"]).to include("jekyll-remote-theme")
@@ -150,7 +150,7 @@ describe(GitHubPages::Configuration) do
   end
 
   context "#set being called via the hook" do
-    let(:override_config) { {"future" => true} }
+    let(:override_config) { { "future" => true } }
 
     it "sets configuration defaults" do
       expect(site.config["kramdown"]["input"]).to eql("GFM")


### PR DESCRIPTION
In GitHub Pages, we manually read the configuration files instead of relying on `Jekyll.configuration` like Jekyll does. This leads to some confusing behavior between local Jekyll runs and production GitHub Pages runs.

This PR moves the reading logic into this gem which the production system can then rely on.

The key parts:

1. Added a class called `GitHubPages::ConfigurationReader` whose sole purpose is to read configuration files and merge them together (no defaults or anything applied!)
2. Use the ConfigurationReader in the tests so we can match production (and use it in production too!)
3. Ensure things like `DEFAULTS["exclude"]` are a concatenation of our settings instead of overwriting
4. Update tests to try to allow for easier config overrides.