### PR TITLE
Bump jekyll-github-metadata to 2.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ branches:
     - master
 
 before_install:
+  - gem update --system
   - gem install bundler
 script: "script/cibuild"
 env:

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -27,7 +27,7 @@ module GitHubPages
       "jekyll-paginate"        => "1.1.0",
       "jekyll-coffeescript"    => "1.1.1",
       "jekyll-seo-tag"         => "2.5.0",
-      "jekyll-github-metadata" => "2.9.4",
+      "jekyll-github-metadata" => "2.10.0",
       "jekyll-avatar"          => "0.6.0",
       "jekyll-remote-theme"    => "0.3.1",
 


### PR DESCRIPTION
To get development mode https testing fix for github.com links from https://github.com/jekyll/github-metadata/pull/133