### PR TITLE
Bump jemoji to 0.10.2

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -32,7 +32,7 @@ module GitHubPages
       "jekyll-remote-theme"    => "0.3.1",
 
       # Plugins to match GitHub.com Markdown
-      "jemoji"                       => "0.10.1",
+      "jemoji"                       => "0.10.2",
       "jekyll-mentions"              => "1.4.1",
       "jekyll-relative-links"        => "0.5.3",
       "jekyll-optional-front-matter" => "0.3.0",


### PR DESCRIPTION
That version resolves broken emoji links after GitHub updating its assert host. See https://github.com/jekyll/jemoji/issues/89.