### PR TITLE
Bump activesupport to v4.2.11.1

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -45,7 +45,7 @@ module GitHubPages
       "listen"                    => "3.1.5",
 
       # Pin activesupport because 5.0 is broken on 2.1
-      "activesupport"             => "4.2.10",
+      "activesupport"             => "4.2.11.1",
     }.freeze
 
     # Jekyll and related dependency versions as used by GitHub Pages.


### PR DESCRIPTION
actionview depends on activesupport, the current version of which is
insecure per an e-mail report cc'd to
security_alert@noreply.github.com

> On Thu, Mar 14, 2019 at 5:07 AM GitHub <notifications@github.com> wrote:
> --snip--
> Known critical severity security vulnerability detected in
> actionview >= 4.0.0, < 4.2.11.1 defined in Gemfile.lock.
> Gemfile.lock update suggested: actionview ~> 4.2.11.1.
> --snip--