### PR TITLE
[Security] Require nokogiri 1.10.4 or greater

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("mercenary", "~> 0.3")
   s.add_dependency("terminal-table", "~> 1.4")
-  s.add_dependency("nokogiri", ">= 1.10.3", "< 2.0")
+  s.add_dependency("nokogiri", ">= 1.10.4", "< 2.0")
   s.add_development_dependency("rspec", "~> 3.3")
   s.add_development_dependency("rainbow", "~> 2.1.0")
   s.add_development_dependency("pry", "~> 0.10")

--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("mercenary", "~> 0.3")
   s.add_dependency("terminal-table", "~> 1.4")
-  s.add_dependency("nokogiri", ">= 1.8.5", "< 2.0")
+  s.add_dependency("nokogiri", ">= 1.10.3", "< 2.0")
   s.add_development_dependency("rspec", "~> 3.3")
   s.add_development_dependency("rainbow", "~> 2.1.0")
   s.add_development_dependency("pry", "~> 0.10")


### PR DESCRIPTION
Addresses CVE-2019-11068
https://nvd.nist.gov/vuln/detail/CVE-2019-11068

**Nokogiri gem, via libxslt, is affected by improper access control vulnerability**

Fixes #636