### PR TITLE
Bump gem versions for rouge v3.3.0 suport.

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -12,11 +12,11 @@ module GitHubPages
 
       # Converters
       "kramdown"                  => "1.17.0",
-      "jekyll-commonmark-ghpages" => "0.1.5",
+      "jekyll-commonmark-ghpages" => "0.1.6",
 
       # Misc
       "liquid"                    => "4.0.0",
-      "rouge"                     => "2.2.1",
+      "rouge"                     => "3.3.0",
       "github-pages-health-check" => "1.16.1",
 
       # Plugins


### PR DESCRIPTION
Update rouge to v3.3.0.

`jekyl-commonmark-ghpages` had a gemspec on v0.1.5 that was not compatible with rouge v3.3.0, but that is resolved in v0.1.6.

Related to https://github.com/github/pages-gem/pull/597, https://github.com/github/pages-gem/pull/635.

Closes https://github.com/github/pages-gem/issues/601.