### PR TITLE
Bump ruby version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
 
 branches:
   only:


### PR DESCRIPTION
👋  Bump Travis to latest available `2.6` Ruby version.

There seem to be some inconsistency on Ruby versions between
- https://github.com/github/pages-gem/blob/master/.rubocop.yml#L19
- https://github.com/github/pages-gem/blob/master/Dockerfile#L1
- https://github.com/github/pages-gem/blob/master/.ruby-version#L1

Happy to bump these to the latest version if that would be is a desired functionality.