### PR TITLE
Bump rouge to v3.11.0

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -16,7 +16,7 @@ module GitHubPages
 
       # Misc
       "liquid"                    => "4.0.0",
-      "rouge"                     => "2.2.1",
+      "rouge"                     => "3.11.0",
       "github-pages-health-check" => "1.16.1",
 
       # Plugins

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -12,7 +12,7 @@ module GitHubPages
 
       # Converters
       "kramdown"                  => "1.17.0",
-      "jekyll-commonmark-ghpages" => "0.1.5",
+      "jekyll-commonmark-ghpages" => "0.1.6",
 
       # Misc
       "liquid"                    => "4.0.0",


### PR DESCRIPTION
Supersedes #635 and #597.

Fixes #601.