### PR TITLE
Un-pin activesupport

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -43,9 +43,6 @@ module GitHubPages
       # Pin listen because it's broken on 2.1 & that's what we recommend.
       # https://github.com/guard/listen/pull/371
       "listen"                    => "3.1.5",
-
-      # Pin activesupport because 5.0 is broken on 2.1
-      "activesupport"             => "4.2.11.1",
     }.freeze
 
     # Jekyll and related dependency versions as used by GitHub Pages.

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -42,7 +42,7 @@ module GitHubPages
 
       # Pin listen because it's broken on 2.1 & that's what we recommend.
       # https://github.com/guard/listen/pull/371
-      "listen"                    => "3.1.5",
+      "listen" => "3.1.5",
     }.freeze
 
     # Jekyll and related dependency versions as used by GitHub Pages.

--- a/spec/github-pages/dependencies_spec.rb
+++ b/spec/github-pages/dependencies_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe(GitHubPages::Dependencies) do
   CORE_DEPENDENCIES = %w(
     jekyll kramdown liquid rouge jekyll-sass-converter
-    github-pages-health-check listen activesupport
+    github-pages-health-check listen
   ).freeze
   PLUGINS = described_class::VERSIONS.keys - CORE_DEPENDENCIES
 


### PR DESCRIPTION
This allows users to specify their preferred activesupport version within the confines of the other dependencies.

Fixes #654.