### PR TITLE
Fix Rouge ambiguous guess error

### DIFF
--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -22,6 +22,9 @@ module GitHubPages
         "input"     => "GFM",
         "hard_wrap" => false,
         "gfm_quirks" => "paragraph_end",
+        "syntax_highlighter_opts" => {
+          "default_lang" => "plaintext",
+        },
       },
       "exclude" => ["CNAME"],
     }.freeze

--- a/spec/fixtures/_posts/2019-10-10-ambiguous-code-block.md
+++ b/spec/fixtures/_posts/2019-10-10-ambiguous-code-block.md
@@ -1,0 +1,25 @@
+---
+title: Ambiguous Code Block
+---
+
+Testing an ambiguous code block. Rouge gets tripped up by this.
+
+## **Header**
+
+This is a paragraph.
+
+    <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+
+    <html>
+
+    <head>
+
+    </head>
+
+    <body>
+
+    </body>
+
+    </html>
+
+This is a paragraph.


### PR DESCRIPTION
When Rouge can't accurately guess a code block's language, it raises an
error. This can be fixed by adding a default language that Rouge falls back
on.