### PR TITLE
Bump minima to v2.5.1

### DIFF
--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -49,7 +49,7 @@ module GitHubPages
     # Themes
     THEMES = {
       "jekyll-swiss"               => "0.4.0",
-      "minima"                     => "2.5.0",
+      "minima"                     => "2.5.1",
       "jekyll-theme-primer"        => "0.5.3",
       "jekyll-theme-architect"     => "0.1.1",
       "jekyll-theme-cayman"        => "0.1.1",


### PR DESCRIPTION
Released some time ago: https://github.com/jekyll/minima/releases/tag/v2.5.1