### PR TITLE
Update jekyll-feed to v0.13.0

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -22,7 +22,7 @@ module GitHubPages
       # Plugins
       "jekyll-redirect-from" => "0.14.0",
       "jekyll-sitemap" => "1.2.0",
-      "jekyll-feed" => "0.11.0",
+      "jekyll-feed" => "0.13.0",
       "jekyll-gist" => "1.5.0",
       "jekyll-paginate" => "1.1.0",
       "jekyll-coffeescript" => "1.1.1",


### PR DESCRIPTION
New release of jekyll-feed gem. There is version 0.13.0.
Release: https://github.com/jekyll/jekyll-feed/releases/tag/v0.13.0