### PR TITLE
Bundled gem updates

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -33,7 +33,7 @@ module GitHubPages
 
       # Plugins to match GitHub.com Markdown
       "jemoji" => "0.11.1",
-      "jekyll-mentions" => "1.4.1",
+      "jekyll-mentions" => "1.5.1",
       "jekyll-relative-links" => "0.6.0",
       "jekyll-optional-front-matter" => "0.3.0",
       "jekyll-readme-index" => "0.2.0",

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -29,7 +29,7 @@ module GitHubPages
       "jekyll-seo-tag" => "2.6.1",
       "jekyll-github-metadata" => "2.12.1",
       "jekyll-avatar" => "0.7.0",
-      "jekyll-remote-theme" => "0.4.0",
+      "jekyll-remote-theme" => "0.4.1",
 
       # Plugins to match GitHub.com Markdown
       "jemoji" => "0.10.2",

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -26,7 +26,7 @@ module GitHubPages
       "jekyll-gist" => "1.5.0",
       "jekyll-paginate" => "1.1.0",
       "jekyll-coffeescript" => "1.1.1",
-      "jekyll-seo-tag" => "2.5.0",
+      "jekyll-seo-tag" => "2.6.1",
       "jekyll-github-metadata" => "2.12.1",
       "jekyll-avatar" => "0.6.0",
       "jekyll-remote-theme" => "0.4.0",

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -39,9 +39,6 @@ module GitHubPages
       "jekyll-readme-index" => "0.3.0",
       "jekyll-default-layout" => "0.1.4",
       "jekyll-titles-from-headings" => "0.5.3",
-
-      # Pin activesupport because 5.0 is broken on 2.1
-      "activesupport" => "4.2.11.1",
     }.freeze
 
     # Jekyll and related dependency versions as used by GitHub Pages.

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -16,7 +16,7 @@ module GitHubPages
 
       # Misc
       "liquid" => "4.0.3",
-      "rouge" => "3.11.0",
+      "rouge" => "3.13.0",
       "github-pages-health-check" => "1.16.1",
 
       # Plugins

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -32,7 +32,7 @@ module GitHubPages
       "jekyll-remote-theme" => "0.4.1",
 
       # Plugins to match GitHub.com Markdown
-      "jemoji" => "0.10.2",
+      "jemoji" => "0.11.1",
       "jekyll-mentions" => "1.4.1",
       "jekyll-relative-links" => "0.6.0",
       "jekyll-optional-front-matter" => "0.3.0",

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -28,7 +28,7 @@ module GitHubPages
       "jekyll-coffeescript" => "1.1.1",
       "jekyll-seo-tag" => "2.6.1",
       "jekyll-github-metadata" => "2.12.1",
-      "jekyll-avatar" => "0.6.0",
+      "jekyll-avatar" => "0.7.0",
       "jekyll-remote-theme" => "0.4.0",
 
       # Plugins to match GitHub.com Markdown

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -15,7 +15,7 @@ module GitHubPages
       "jekyll-commonmark-ghpages" => "0.1.6",
 
       # Misc
-      "liquid" => "4.0.0",
+      "liquid" => "4.0.3",
       "rouge" => "3.11.0",
       "github-pages-health-check" => "1.16.1",
 

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -40,10 +40,6 @@ module GitHubPages
       "jekyll-default-layout" => "0.1.4",
       "jekyll-titles-from-headings" => "0.5.3",
 
-      # Pin listen because it's broken on 2.1 & that's what we recommend.
-      # https://github.com/guard/listen/pull/371
-      "listen" => "3.1.5",
-
       # Pin activesupport because 5.0 is broken on 2.1
       "activesupport" => "4.2.11.1",
     }.freeze

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -21,7 +21,7 @@ module GitHubPages
 
       # Plugins
       "jekyll-redirect-from" => "0.15.0",
-      "jekyll-sitemap" => "1.2.0",
+      "jekyll-sitemap" => "1.4.0",
       "jekyll-feed" => "0.11.0",
       "jekyll-gist" => "1.5.0",
       "jekyll-paginate" => "1.1.0",

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -38,7 +38,7 @@ module GitHubPages
       "jekyll-optional-front-matter" => "0.3.2",
       "jekyll-readme-index" => "0.3.0",
       "jekyll-default-layout" => "0.1.4",
-      "jekyll-titles-from-headings" => "0.5.1",
+      "jekyll-titles-from-headings" => "0.5.3",
 
       # Pin listen because it's broken on 2.1 & that's what we recommend.
       # https://github.com/guard/listen/pull/371

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -34,7 +34,7 @@ module GitHubPages
       # Plugins to match GitHub.com Markdown
       "jemoji" => "0.11.1",
       "jekyll-mentions" => "1.5.1",
-      "jekyll-relative-links" => "0.6.0",
+      "jekyll-relative-links" => "0.6.1",
       "jekyll-optional-front-matter" => "0.3.0",
       "jekyll-readme-index" => "0.2.0",
       "jekyll-default-layout" => "0.1.4",

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -35,7 +35,7 @@ module GitHubPages
       "jemoji" => "0.11.1",
       "jekyll-mentions" => "1.5.1",
       "jekyll-relative-links" => "0.6.1",
-      "jekyll-optional-front-matter" => "0.3.0",
+      "jekyll-optional-front-matter" => "0.3.2",
       "jekyll-readme-index" => "0.2.0",
       "jekyll-default-layout" => "0.1.4",
       "jekyll-titles-from-headings" => "0.5.1",

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -20,7 +20,7 @@ module GitHubPages
       "github-pages-health-check" => "1.16.1",
 
       # Plugins
-      "jekyll-redirect-from" => "0.14.0",
+      "jekyll-redirect-from" => "0.15.0",
       "jekyll-sitemap" => "1.2.0",
       "jekyll-feed" => "0.11.0",
       "jekyll-gist" => "1.5.0",

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -36,7 +36,7 @@ module GitHubPages
       "jekyll-mentions" => "1.5.1",
       "jekyll-relative-links" => "0.6.1",
       "jekyll-optional-front-matter" => "0.3.2",
-      "jekyll-readme-index" => "0.2.0",
+      "jekyll-readme-index" => "0.3.0",
       "jekyll-default-layout" => "0.1.4",
       "jekyll-titles-from-headings" => "0.5.1",
 

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -22,7 +22,7 @@ module GitHubPages
       # Plugins
       "jekyll-redirect-from" => "0.15.0",
       "jekyll-sitemap" => "1.4.0",
-      "jekyll-feed" => "0.11.0",
+      "jekyll-feed" => "0.13.0",
       "jekyll-gist" => "1.5.0",
       "jekyll-paginate" => "1.1.0",
       "jekyll-coffeescript" => "1.1.1",

--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -48,21 +48,21 @@ module GitHubPages
 
     # Themes
     THEMES = {
-      "jekyll-swiss" => "1.0.0",
-      "minima" => "2.5.0",
-      "jekyll-theme-primer" => "0.5.4",
-      "jekyll-theme-architect" => "0.1.1",
-      "jekyll-theme-cayman" => "0.1.1",
-      "jekyll-theme-dinky" => "0.1.1",
-      "jekyll-theme-hacker" => "0.1.1",
-      "jekyll-theme-leap-day" => "0.1.1",
-      "jekyll-theme-merlot" => "0.1.1",
-      "jekyll-theme-midnight" => "0.1.1",
-      "jekyll-theme-minimal" => "0.1.1",
-      "jekyll-theme-modernist" => "0.1.1",
-      "jekyll-theme-slate" => "0.1.1",
-      "jekyll-theme-tactile" => "0.1.1",
-      "jekyll-theme-time-machine" => "0.1.1",
+      "jekyll-swiss"               => "1.0.0",
+      "minima"                     => "2.5.1",
+      "jekyll-theme-primer"        => "0.5.4",
+      "jekyll-theme-architect"     => "0.1.1",
+      "jekyll-theme-cayman"        => "0.1.1",
+      "jekyll-theme-dinky"         => "0.1.1",
+      "jekyll-theme-hacker"        => "0.1.1",
+      "jekyll-theme-leap-day"      => "0.1.1",
+      "jekyll-theme-merlot"        => "0.1.1",
+      "jekyll-theme-midnight"      => "0.1.1",
+      "jekyll-theme-minimal"       => "0.1.1",
+      "jekyll-theme-modernist"     => "0.1.1",
+      "jekyll-theme-slate"         => "0.1.1",
+      "jekyll-theme-tactile"       => "0.1.1",
+      "jekyll-theme-time-machine"  => "0.1.1",
     }.freeze
   end
 end

--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -50,7 +50,7 @@ module GitHubPages
     THEMES = {
       "jekyll-swiss" => "1.0.0",
       "minima" => "2.5.0",
-      "jekyll-theme-primer" => "0.5.3",
+      "jekyll-theme-primer" => "0.5.4",
       "jekyll-theme-architect" => "0.1.1",
       "jekyll-theme-cayman" => "0.1.1",
       "jekyll-theme-dinky" => "0.1.1",

--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -48,7 +48,7 @@ module GitHubPages
 
     # Themes
     THEMES = {
-      "jekyll-swiss" => "0.4.0",
+      "jekyll-swiss" => "1.0.0",
       "minima" => "2.5.0",
       "jekyll-theme-primer" => "0.5.3",
       "jekyll-theme-architect" => "0.1.1",

--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -48,21 +48,21 @@ module GitHubPages
 
     # Themes
     THEMES = {
-      "jekyll-swiss"               => "1.0.0",
-      "minima"                     => "2.5.1",
-      "jekyll-theme-primer"        => "0.5.4",
-      "jekyll-theme-architect"     => "0.1.1",
-      "jekyll-theme-cayman"        => "0.1.1",
-      "jekyll-theme-dinky"         => "0.1.1",
-      "jekyll-theme-hacker"        => "0.1.1",
-      "jekyll-theme-leap-day"      => "0.1.1",
-      "jekyll-theme-merlot"        => "0.1.1",
-      "jekyll-theme-midnight"      => "0.1.1",
-      "jekyll-theme-minimal"       => "0.1.1",
-      "jekyll-theme-modernist"     => "0.1.1",
-      "jekyll-theme-slate"         => "0.1.1",
-      "jekyll-theme-tactile"       => "0.1.1",
-      "jekyll-theme-time-machine"  => "0.1.1",
+      "jekyll-swiss" => "1.0.0",
+      "minima" => "2.5.1",
+      "jekyll-theme-primer" => "0.5.4",
+      "jekyll-theme-architect" => "0.1.1",
+      "jekyll-theme-cayman" => "0.1.1",
+      "jekyll-theme-dinky" => "0.1.1",
+      "jekyll-theme-hacker" => "0.1.1",
+      "jekyll-theme-leap-day" => "0.1.1",
+      "jekyll-theme-merlot" => "0.1.1",
+      "jekyll-theme-midnight" => "0.1.1",
+      "jekyll-theme-minimal" => "0.1.1",
+      "jekyll-theme-modernist" => "0.1.1",
+      "jekyll-theme-slate" => "0.1.1",
+      "jekyll-theme-tactile" => "0.1.1",
+      "jekyll-theme-time-machine" => "0.1.1",
     }.freeze
   end
 end

--- a/spec/github-pages/dependencies_spec.rb
+++ b/spec/github-pages/dependencies_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe(GitHubPages::Dependencies) do
   CORE_DEPENDENCIES = %w(
     jekyll kramdown liquid rouge jekyll-sass-converter
-    github-pages-health-check activesupport
+    github-pages-health-check
   ).freeze
   PLUGINS = described_class::VERSIONS.keys - CORE_DEPENDENCIES
 

--- a/spec/github-pages/dependencies_spec.rb
+++ b/spec/github-pages/dependencies_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe(GitHubPages::Dependencies) do
   CORE_DEPENDENCIES = %w(
     jekyll kramdown liquid rouge jekyll-sass-converter
-    github-pages-health-check listen activesupport
+    github-pages-health-check activesupport
   ).freeze
   PLUGINS = described_class::VERSIONS.keys - CORE_DEPENDENCIES
 

--- a/spec/github-pages/integration_spec.rb
+++ b/spec/github-pages/integration_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Pages Gem Integration spec" do
       contents = File.read(__FILE__)
       contexts = contents.scan(/context \"(.*?)\"/)
       missing = GitHubPages::Dependencies::VERSIONS.keys - contexts.flatten
-      missing -= %w(activesupport github-pages-health-check)
+      missing -= %w(github-pages-health-check)
       msg = "The following dependencies are missing integration tests: #{missing.join(", ")}"
       expect(missing).to be_empty, msg
     end

--- a/spec/github-pages/integration_spec.rb
+++ b/spec/github-pages/integration_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Pages Gem Integration spec" do
       contents = File.read(__FILE__)
       contexts = contents.scan(/context \"(.*?)\"/)
       missing = GitHubPages::Dependencies::VERSIONS.keys - contexts.flatten
-      missing -= %w(listen activesupport github-pages-health-check)
+      missing -= %w(activesupport github-pages-health-check)
       msg = "The following dependencies are missing integration tests: #{missing.join(", ")}"
       expect(missing).to be_empty, msg
     end


### PR DESCRIPTION
- Unpin Listen
- Unpin activesupport
- Update minima to v2.5.1
- Update jekyll-theme-primer to v0.5.4
- Update jekyll-swiss to v1.0.0
- Update jekyll-titles-from-headings to v0.5.3
- Update jekyll-readme-index to v0.3.0
- Update jekyll-optional-front-matter to v0.3.2
- Update jekyll-relative-links to v0.6.1
- Update jekyll-mentions to v1.5.1
- Update jemoji to 0.11.1
- Update jekyll-remote-theme to v0.4.1
- Update jekyll-avatar to v0.7.0
- Update jekyll-seo-tag to v2.6.1
- Update jekyll-feed to v0.13.0
- Update jekyll-sitemap to v1.4.0
- Update jekyll-redirect-from to v0.15.0
- Update rouge to v3.13.0
- Update liquid to v4.0.3