### PR TITLE
Update rouge to v3.18.0

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -16,7 +16,7 @@ module GitHubPages
 
       # Misc
       "liquid" => "4.0.3",
-      "rouge" => "3.13.0",
+      "rouge" => "3.18.0",
       "github-pages-health-check" => "1.16.1",
 
       # Plugins


### PR DESCRIPTION
This brings in fixes to C++, Python, Java, Lua, Rust, Ruby, Scala, Kotlin, PHP, Pascal, TypeScript, CoffeeScript, TOML, Markdown and introduces support (not a comprehensive list) for Varnish, GHC, Objective-C++,  Rego and Solidity.

It would be nice to have these applied to projects using pages. Please let me know if there is a way to override the `rouge` dependency in a project using github-pages.