### PR TITLE
Unbreak running Docker outside CI by setting default Ruby version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUBY_VERSION
+ARG RUBY_VERSION=2.7.1
 FROM ruby:$RUBY_VERSION
 
 RUN apt-get update \


### PR DESCRIPTION
Dockerfile accepts a Ruby version as an argument but the Makefile does not provide one. Resulting in an error when calling `make image`:

```
 ~: make image
docker build -t gh-pages .
Sending build context to Docker daemon  1.232MB
Step 1/17 : ARG RUBY_VERSION
Step 2/17 : FROM ruby:$RUBY_VERSION
invalid reference format
make: *** [image] Error 1
```

Set a default Ruby version to prevent this happening. Version was chosen to be consistent with `.ruby-version`.