### PR TITLE
Train: Upgrade dependencies

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -23,7 +23,7 @@ module GitHubPages
       # Plugins
       "jekyll-redirect-from" => "0.16.0",
       "jekyll-sitemap" => "1.4.0",
-      "jekyll-feed" => "0.13.0",
+      "jekyll-feed" => "0.15.0",
       "jekyll-gist" => "1.5.0",
       "jekyll-paginate" => "1.1.0",
       "jekyll-coffeescript" => "1.1.1",

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -33,7 +33,7 @@ module GitHubPages
       "jekyll-remote-theme" => "0.4.2",
 
       # Plugins to match GitHub.com Markdown
-      "jemoji" => "0.11.1",
+      "jemoji" => "0.12.0",
       "jekyll-mentions" => "1.6.0",
       "jekyll-relative-links" => "0.6.1",
       "jekyll-optional-front-matter" => "0.3.2",

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -34,7 +34,7 @@ module GitHubPages
 
       # Plugins to match GitHub.com Markdown
       "jemoji" => "0.11.1",
-      "jekyll-mentions" => "1.5.1",
+      "jekyll-mentions" => "1.6.0",
       "jekyll-relative-links" => "0.6.1",
       "jekyll-optional-front-matter" => "0.3.2",
       "jekyll-readme-index" => "0.3.0",

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -30,7 +30,7 @@ module GitHubPages
       "jekyll-seo-tag" => "2.6.1",
       "jekyll-github-metadata" => "2.13.0",
       "jekyll-avatar" => "0.7.0",
-      "jekyll-remote-theme" => "0.4.1",
+      "jekyll-remote-theme" => "0.4.2",
 
       # Plugins to match GitHub.com Markdown
       "jemoji" => "0.11.1",

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -21,7 +21,7 @@ module GitHubPages
       "github-pages-health-check" => "1.16.1",
 
       # Plugins
-      "jekyll-redirect-from" => "0.15.0",
+      "jekyll-redirect-from" => "0.16.0",
       "jekyll-sitemap" => "1.4.0",
       "jekyll-feed" => "0.13.0",
       "jekyll-gist" => "1.5.0",

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -17,7 +17,7 @@ module GitHubPages
 
       # Misc
       "liquid" => "4.0.3",
-      "rouge" => "3.19.0",
+      "rouge" => "3.23.0",
       "github-pages-health-check" => "1.16.1",
 
       # Plugins

--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -54,7 +54,7 @@ module GitHubPages
       "jekyll-theme-architect" => "0.1.1",
       "jekyll-theme-cayman" => "0.1.1",
       "jekyll-theme-dinky" => "0.1.1",
-      "jekyll-theme-hacker" => "0.1.1",
+      "jekyll-theme-hacker" => "0.1.2",
       "jekyll-theme-leap-day" => "0.1.1",
       "jekyll-theme-merlot" => "0.1.1",
       "jekyll-theme-midnight" => "0.1.1",


### PR DESCRIPTION
This is a PR train, merging several smaller PRs into one for easier testing.

- #711 - Update rouge to :gem: v3.23.0
- #707 - Update jekyll-redirect-from to :gem: v0.16.0
- #710 - Update Jekyll-feed to :gem: v0.15.0
- #712 - Update jekyll-remote-theme to :gem: v0.4.2
- #713 - Update Jekyll-mentions to :gem: v1.6.0
- #714 - Update jekyll-theme-hacker to :gem: v0.1.2
- #715 - Update jemoji to :gem: v0.12.0