### PR TITLE
Nil for kramdown math_engine and syntax highlighter

### DIFF
--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -22,6 +22,8 @@ module GitHubPages
         "input" => "GFM",
         "hard_wrap" => false,
         "gfm_quirks" => "paragraph_end",
+        "math_engine" => "mathjax",
+        "syntax_highlighter" => "rouge",
         "syntax_highlighter_opts" => {
           "default_lang" => "plaintext",
         },
@@ -54,8 +56,6 @@ module GitHubPages
       "highlighter" => "rouge",
       "kramdown" => {
         "template" => "",
-        "math_engine" => "mathjax",
-        "syntax_highlighter" => "rouge",
       },
       "gist" => {
         "noscript" => false,
@@ -106,6 +106,14 @@ module GitHubPages
 
         # Allow theme to be explicitly disabled via "theme: null"
         config["theme"] = user_config["theme"] if user_config.key?("theme")
+
+        # Override non-nil values for kramdown options math_engine and syntax_highlighter
+        unless config["kramdown"]["math_engine"].nil?
+          config["kramdown"]["math_engine"] = DEFAULTS["kramdown"]["math_engine"]
+        end
+        unless config["kramdown"]["syntax_highlighter"].nil?
+          config["kramdown"]["syntax_highlighter"] = DEFAULTS["kramdown"]["syntax_highlighter"]
+        end
 
         exclude_cname(config)
 

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -107,14 +107,6 @@ module GitHubPages
         # Allow theme to be explicitly disabled via "theme: null"
         config["theme"] = user_config["theme"] if user_config.key?("theme")
 
-        # Override non-nil values for kramdown options math_engine and syntax_highlighter
-        unless config["kramdown"]["math_engine"].nil?
-          config["kramdown"]["math_engine"] = DEFAULTS["kramdown"]["math_engine"]
-        end
-        unless config["kramdown"]["syntax_highlighter"].nil?
-          config["kramdown"]["syntax_highlighter"] = DEFAULTS["kramdown"]["syntax_highlighter"]
-        end
-
         exclude_cname(config)
 
         # Merge overwrites into user config
@@ -149,11 +141,19 @@ module GitHubPages
       # Ensure we're using Kramdown or GFM.  Force to Kramdown if
       # neither of these.
       #
+      # Also override non-nil values for kramdown options math_engine and
+      # syntax_highlighter.
+      #
       # This can get called multiply on the same config, so try to
       # be idempotentish.
       def restrict_and_config_markdown_processor(config)
         config["markdown"] = "kramdown" unless \
           %w(kramdown gfm commonmarkghpages).include?(config["markdown"].to_s.downcase)
+
+        %w(math_engine syntax_highlighter).each do |opt|
+          config["kramdown"][opt] = DEFAULTS["kramdown"][opt] unless \
+            config["kramdown"][opt].nil?
+        end
 
         return unless config["markdown"].to_s.casecmp("gfm").zero?
 

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -151,8 +151,8 @@ module GitHubPages
           %w(kramdown gfm commonmarkghpages).include?(config["markdown"].to_s.downcase)
 
         %w(math_engine syntax_highlighter).each do |opt|
-          config["kramdown"][opt] = DEFAULTS["kramdown"][opt] unless \
-            config["kramdown"][opt].nil?
+          config["kramdown"][opt] = \
+            config["kramdown"][opt] == "nil" ? nil : DEFAULTS["kramdown"][opt]
         end
 
         return unless config["markdown"].to_s.casecmp("gfm").zero?

--- a/spec/github-pages/configuration_spec.rb
+++ b/spec/github-pages/configuration_spec.rb
@@ -49,6 +49,25 @@ describe(GitHubPages::Configuration) do
       expect(effective_config["quiet"]).to eql(true)
     end
 
+    it "has default values for math_engine and syntax_highlighter" do
+      expect(effective_config["kramdown"]["math_engine"]).to eql("mathjax")
+      expect(effective_config["kramdown"]["syntax_highlighter"]).to eql("rouge")
+    end
+
+    it "respects 'nil' for math_engine and syntax_highlighter" do
+      config = configuration.merge("kramdown" => { "math_engine" => "nil", "syntax_highlighter" => "nil" })
+      effective_config = described_class.effective_config(config)
+      expect(effective_config["kramdown"]["math_engine"]).to be_nil
+      expect(effective_config["kramdown"]["syntax_highlighter"]).to be_nil
+    end
+
+    it "overrides non-'nil' for math_engine and syntax_highlighter" do
+      config = configuration.merge("kramdown" => { "math_engine" => "foo", "syntax_highlighter" => "bar" })
+      effective_config = described_class.effective_config(config)
+      expect(effective_config["kramdown"]["math_engine"]).to eql("mathjax")
+      expect(effective_config["kramdown"]["syntax_highlighter"]).to eql("rouge")
+    end
+
     it "passes passthroughs" do
       expect(effective_config["quiet"]).to eql(true)
       expect(effective_config["source"]).to eql(fixture_dir)


### PR DESCRIPTION
This is a redo of #644, which allows users to explicitly turn off math engine and syntax highlighter of kramdown. There was some discussion on that PR, but after my last comment, I wasn't sure what other changes were requested.