### PR TITLE
allow for extra args to github-pages docker

### DIFF
--- a/contrib/func.sh
+++ b/contrib/func.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/env sh
-# The github-pages function optionally takes two arguments
-#  - the first argument is the path to the Jekyll site
-#  - the second argument is the port number
+
 function github-pages {
-  _path=${1:-.}
-  _port=${2:-4000}
+  _path=${GH_PATH:-.}
+  _port=${GH_PORT:-4000}
   docker run --rm \
     -p $_port:4000 \
     -u `id -u`:`id -g` \
     -v `realpath $_path`:/src/site \
-    gh-pages
+    gh-pages jekyll serve -H 0.0.0.0 -P 4000 $@
 }

--- a/contrib/func.sh
+++ b/contrib/func.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+# The github-pages function optionally reads two environment variables
+#  - the first is the path to the Jekyll site (GH_PATH)
+#  - the second is the port number (GH_PORT)
 
 function github-pages {
   _path=${GH_PATH:-.}


### PR DESCRIPTION
It is often useful to have this docker image serving the site while you work on drafts. In order to do that, you need to have the docker image serve up drafts. This allows you to execute that (as well as any other flags or options) relatively easily.

Example usage:
```bash
$ github-pages
# runs like it did before
$ GH_PORT=12345 github-pages
# runs like github-pages 12345 used to
$ github-pages --drafts
# runs github-pages but displays drafts
```