### PR TITLE
Use Ruby 2.7.1 in Dockerfile.alpine

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM ruby:alpine
+FROM ruby:2.7.1-alpine
 
 RUN apk update && apk add --no-cache \
   git


### PR DESCRIPTION
This matches the actual version of Ruby [used by GitHub pages](https://pages.github.com/versions/), as specified in [.ruby-version](https://github.com/github/pages-gem/blob/master/.ruby-version).

On master:

```console
$ docker build -t gh-pages .
Sending build context to Docker daemon  886.3kB
Step 1/9 : FROM ruby:alpine
alpine: Pulling from library/ruby
4c0d98bf9879: Pull complete
e5fcc264663b: Pull complete
1c151e279a03: Pull complete
5ba67da12582: Pull complete
0816342c8486: Pull complete
Digest: sha256:5a1e0a3cf60f570854391b215cb33fe625bf21b90195909d540625b5becd293a
Status: Downloaded newer image for ruby:alpine
 ---> 91cbdb8db2c7
︙

$ docker run --rm -it gh-pages /bin/sh
/src/site # ruby -v
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-linux-musl]
```

On this branch:

```console
$ docker build -t gh-pages .
Sending build context to Docker daemon  886.3kB
Step 1/9 : FROM ruby:2.7.1-alpine
2.7.1-alpine: Pulling from library/ruby
df20fa9351a1: Pull complete
b79bab524d4c: Pull complete
8f5dd72031b5: Pull complete
bea36b8d88de: Pull complete
3396c77940f8: Pull complete
Digest: sha256:73814d17e9f746ca21a67a4cde96ab81e858bbe9e6bf78257fbb5def033f2b82
Status: Downloaded newer image for ruby:2.7.1-alpine
 ---> b46ea0bc5984
︙

$ docker run --rm -it gh-pages /bin/sh
/src/site # ruby -v
ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-linux-musl]
```

/cc @casperdcl from #560.