### PR TITLE
Add a script to validate all the themes we support

### DIFF
--- a/.github/workflows/validate-themes.yml
+++ b/.github/workflows/validate-themes.yml
@@ -1,0 +1,14 @@
+on:
+  - push
+  - pull_request
+name: validate themes
+jobs:
+  build:
+    name: "GitHub Pages: Validate Themes"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Validate themes
+      run: script/docker-run script/validate-themes
+      env:
+        RUBY_VERSION: 2.7

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,7 @@ group :test do
   gem "rubocop-performance"
   gem "webmock"
 end
+
+group :development do
+  gem "solargraph"
+end

--- a/script/cibuild-docker
+++ b/script/cibuild-docker
@@ -2,8 +2,4 @@
 
 set -ex
 
-# Set the ruby version in the Action definition matrix.
-: "${RUBY_VERSION:="2.7.3"}"
-
-docker build --build-arg "RUBY_VERSION=$RUBY_VERSION" -t github-pages .
-docker run --rm --workdir /src/gh/pages-gem github-pages script/cibuild
+script/docker-run script/cibuild

--- a/script/docker-run
+++ b/script/docker-run
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -ex
+
+# Set the ruby version in the Action definition matrix.
+: "${RUBY_VERSION:="2.7.3"}"
+
+docker build --build-arg "RUBY_VERSION=$RUBY_VERSION" -t github-pages .
+docker run --rm --workdir /src/gh/pages-gem github-pages "$@"

--- a/script/test-site
+++ b/script/test-site
@@ -6,11 +6,15 @@ set -e
 rm -Rf ./test-site
 bundle exec jekyll new test-site
 
-BUNDLE_GEMFILE="$(pwd)/Gemfile"
-export BUNDLE_GEMFILE
-
 cd test-site
-rm -Rf Gemfile
+echo 'source "https://rubygems.org"' > Gemfile
+echo 'gem "github-pages", path: "../", group: :jekyll_plugins' >> Gemfile
+bundle install
+
+theme_name="$1"
+if [ -n "$theme_name" ]; then
+  echo "theme: $theme_name" >> _config.yml
+fi
 
 echo "Using $(bundle exec github-pages --version)"
 echo "Using $(bundle exec jekyll --version)"

--- a/script/test-site-remote-theme
+++ b/script/test-site-remote-theme
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Test that the default Jekyll site builds with a given remote theme
+
+set -e
+
+rm -Rf ./test-site
+bundle exec jekyll new --blank test-site
+
+cd test-site
+echo 'source "https://rubygems.org"' > Gemfile
+echo 'gem "github-pages", path: "../", group: :jekyll_plugins' >> Gemfile
+bundle install
+
+echo "title: Your awesome title" > _config.yml
+
+theme_name="$1"
+if [ -n "$theme_name" ]; then
+  echo "theme: null" >> _config.yml
+  echo "remote_theme: $theme_name" >> _config.yml
+  echo "plugins: [jekyll-remote-theme]" >> _config.yml
+fi
+
+rm -Rf index.html
+echo "---" > index.md
+echo "layout: page" >> index.md
+echo "---" >> index.md
+echo "" >> index.md
+echo "{{site.title}} rendered using {{site.remote_theme}}" >> index.md
+
+echo "Using $(bundle exec github-pages --version)"
+echo "Using $(bundle exec jekyll --version)"
+bundle exec jekyll build --trace --verbose
+
+grep --quiet "Your awesome title" ./_site/index.html
+grep --quiet "$theme_name" ./_site/index.html
+echo "Site built!"
+
+cd ..
+rm -Rf ./test-site

--- a/script/validate-themes
+++ b/script/validate-themes
@@ -1,0 +1,49 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "github-pages"
+require "open3"
+
+failure = false
+
+def test_site(theme_name: nil, remote_theme_name: nil)
+  if theme_name.nil? && remote_theme_name.nil?
+    raise "theme_name: or remote_theme_name: required"
+  end
+
+  command = if theme_name
+              ["script/test-site", theme_name]
+            else
+              ["script/test-site-remote-theme", remote_theme_name]
+            end
+
+  exit_status = nil
+  puts "Executing #{command}"
+  Open3.popen2e(*command) { |stdin, stdout_and_stderr, wait_thr|
+    stdout_and_stderr.each { |line|
+      puts line
+    }
+    exit_status = wait_thr.value
+  }
+  exit_status.success?
+end
+
+# Gem-based themes
+GitHubPages::Plugins::THEMES.each do |theme_name, version|
+  puts "Testing theme #{theme_name}..."
+  unless test_site(theme_name: theme_name) # rubocop:disable Style/HashSyntax
+    failure = true
+    puts "FAILURE for #{theme_name}"
+  end
+end
+
+# Remote Themes
+GitHubPages::Plugins::THEMES_TO_CONVERT_TO_REMOTE_THEMES.each do |_theme_name, remote_theme|
+  puts "Testing remote theme #{remote_theme}..."
+  unless test_site(remote_theme_name: remote_theme) # rubocop:disable Style/HashSyntax
+    puts "FAILURE for #{remote_theme}"
+    failure = true
+  end
+end
+
+abort "FAILURE" if failure


### PR DESCRIPTION
In #772, we removed the `jekyll-theme-<theme_name>` themes from this gem and replaced them with `remote_theme` declarations which are equivalent. In doing so, we accidentally broke the local development process. Folks with `theme: jekyll-theme-<theme_name>` need to change to use `remote_theme: pages-themes/<theme_name>@v0.2.0` instead to get their site to build locally.

In order to prevent future local build breakages, this PR proposes a new CI target to test building a Jekyll site with each theme.

Related to #777 