### PR TITLE
[Security] Require nokogiri 1.12.5 or greater

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency("mercenary", "~> 0.3")
-  s.add_dependency("nokogiri", ">= 1.10.4", "< 2.0")
+  s.add_dependency("nokogiri", ">= 1.12.5", "< 2.0")
   s.add_dependency("terminal-table", "~> 1.4")
   s.add_development_dependency("jekyll_test_plugin_malicious", "~> 0.2")
   s.add_development_dependency("pry", "~> 0.10")


### PR DESCRIPTION
Address CVE-2021-41098
https://github.com/advisories/GHSA-2rr5-8q37-2w7h

In Nokogiri v1.12.4 and earlier, on JRuby only, the SAX parser resolves external entities by default.

Fix #796 