### PR TITLE
Add build functionality to `github-pages` executable

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,35 @@
+name: Publish to Docker
+on:
+  push:
+    branches: [ master ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ master ]
+ 
+env:
+  DOCKER_TAG_IMAGE: "ghcr.io/github/pages-gem"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Get Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.DOCKER_TAG_IMAGE }}
+
+      - name: Build Docker Image
+        run: |
+          docker build -t ${{ steps.meta.outputs.tags }} -f Dockerfile .
+
+      - name: Push to Container Registry
+        if: github.event_name != 'pull_request'
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ github.actor }} https://ghcr.io --password-stdin
+          docker push ${{ steps.meta.outputs.tags }}
+

--- a/bin/github-pages
+++ b/bin/github-pages
@@ -56,4 +56,17 @@ Mercenary.program(:"github-pages") do |p|
       end
     end
   end
+
+  p.command(:build) do |c|
+    c.syntax "build [options]"
+    c.description "Builds your Jekyll site"
+
+    c.option 'verbose', '--verbose', 'Verbose logging'
+    c.option 'source', '--source DIR', 'From where to collect the source files'
+    c.option 'destination', '--destination DIR', 'To where the compiled files should be written'
+
+    c.action do |_, options|
+      Jekyll::Commands::Build.process(options)
+    end
+  end
 end


### PR DESCRIPTION
Adds the `build` option to the `github-pages` executable and add CI to build and publish Docker images (publish only on `main` and `v*` tagged branches)