### PR TITLE
Add missing dependencies

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -31,6 +31,7 @@ module GitHubPages
       "jekyll-github-metadata" => "2.13.0",
       "jekyll-avatar" => "0.7.0",
       "jekyll-remote-theme" => "0.4.3",
+      "jekyll-include-cache" => "0.2.1",
 
       # Plugins to match GitHub.com Markdown
       "jemoji" => "0.12.0",

--- a/spec/fixtures/_config.yml
+++ b/spec/fixtures/_config.yml
@@ -11,6 +11,7 @@ gems:
   - jemoji
   - jekyll-mentions
   - jekyll_test_plugin_malicious
+  - jekyll-include-cache
 quiet: false
 paginate: 5
 github:

--- a/spec/fixtures/_config_with_gfm.yml
+++ b/spec/fixtures/_config_with_gfm.yml
@@ -12,6 +12,7 @@ gems:
   - jemoji
   - jekyll-mentions
   - jekyll_test_plugin_malicious
+  - jekyll-include-cache
 quiet: false
 paginate: 5
 github:

--- a/spec/fixtures/_config_with_remote_theme.yml
+++ b/spec/fixtures/_config_with_remote_theme.yml
@@ -11,6 +11,7 @@ gems:
   - jemoji
   - jekyll-mentions
   - jekyll_test_plugin_malicious
+  - jekyll-include-cache
 quiet: false
 paginate: 5
 github:

--- a/spec/fixtures/_includes/cached.html
+++ b/spec/fixtures/_includes/cached.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <h1 id="cached">Hi from the cache {{ include.name }}!!!</h1>
+  </body>
+</html>

--- a/spec/fixtures/jekyll-include-cache.html
+++ b/spec/fixtures/jekyll-include-cache.html
@@ -1,0 +1,4 @@
+---
+---
+
+{% include_cached cached.html name="Test User" %}

--- a/spec/github-pages/integration_spec.rb
+++ b/spec/github-pages/integration_spec.rb
@@ -273,6 +273,12 @@ RSpec.describe "Pages Gem Integration spec" do
         expect(contents).to match('aria-label="hi"')
       end
     end
+
+    context "jekyll-include-cache" do
+      it "works" do
+        expect(contents).to match('<h1 id="cached">Hi from the cache Test User!!!</h1>')
+      end
+    end
   end
 
   context "fixture site with remote theme config" do


### PR DESCRIPTION
Added `jekyll-include-case` plugin.

Current list of included gems.

```
Gems included by the bundle:
  * activesupport (6.0.4.1)
  * addressable (2.8.0)
  * ast (2.4.2)
  * coderay (1.1.3)
  * coffee-script (2.4.1)
  * coffee-script-source (1.11.1)
  * colorator (1.1.0)
  * commonmarker (0.17.13)
  * concurrent-ruby (1.1.9)
  * crack (0.4.5)
  * diff-lcs (1.4.4)
  * dnsruby (1.61.7)
  * em-websocket (0.5.3)
  * ethon (0.15.0)
  * eventmachine (1.2.7)
  * execjs (2.8.1)
  * faraday (1.8.0)
  * faraday-em_http (1.0.0)
  * faraday-em_synchrony (1.0.0)
  * faraday-excon (1.1.0)
  * faraday-httpclient (1.0.1)
  * faraday-net_http (1.0.1)
  * faraday-net_http_persistent (1.2.0)
  * faraday-patron (1.0.0)
  * faraday-rack (1.0.0)
  * ffi (1.15.4)
  * forwardable-extended (2.6.0)
  * gemoji (3.0.1)
  * github-pages (221)
  * github-pages-health-check (1.17.9)
  * hashdiff (1.0.1)
  * html-pipeline (2.14.0)
  * http_parser.rb (0.8.0)
  * i18n (0.9.5)
  * jaro_winkler (1.5.4)
  * jekyll (3.9.0)
  * jekyll-avatar (0.7.0)
  * jekyll-coffeescript (1.1.1)
  * jekyll-commonmark (1.3.1)
  * jekyll-commonmark-ghpages (0.1.6)
  * jekyll-default-layout (0.1.4)
  * jekyll-feed (0.15.1)
  * jekyll-gist (1.5.0)
  * jekyll-github-metadata (2.13.0)
  * jekyll-include-cache (0.2.1)
  * jekyll-mentions (1.6.0)
  * jekyll-octicons (16.1.1)
  * jekyll-optional-front-matter (0.3.2)
  * jekyll-paginate (1.1.0)
  * jekyll-readme-index (0.3.0)
  * jekyll-redirect-from (0.16.0)
  * jekyll-relative-links (0.6.1)
  * jekyll-remote-theme (0.4.3)
  * jekyll-sass-converter (1.5.2)
  * jekyll-seo-tag (2.7.1)
  * jekyll-sitemap (1.4.0)
  * jekyll-swiss (1.0.0)
  * jekyll-theme-architect (0.2.0)
  * jekyll-theme-cayman (0.2.0)
  * jekyll-theme-dinky (0.2.0)
  * jekyll-theme-hacker (0.2.0)
  * jekyll-theme-leap-day (0.2.0)
  * jekyll-theme-merlot (0.2.0)
  * jekyll-theme-midnight (0.2.0)
  * jekyll-theme-minimal (0.2.0)
  * jekyll-theme-modernist (0.2.0)
  * jekyll-theme-primer (0.6.0)
  * jekyll-theme-slate (0.2.0)
  * jekyll-theme-tactile (0.2.0)
  * jekyll-theme-time-machine (0.2.0)
  * jekyll-titles-from-headings (0.5.3)
  * jekyll-watch (2.2.1)
  * jekyll_test_plugin_malicious (0.2.0)
  * jemoji (0.12.0)
  * kramdown (2.3.1)
  * kramdown-parser-gfm (1.1.0)
  * liquid (4.0.3)
  * listen (3.7.0)
  * mercenary (0.3.6)
  * method_source (1.0.0)
  * minima (2.5.1)
  * minitest (5.14.4)
  * multipart-post (2.1.1)
  * nokogiri (1.12.5)
  * octicons (16.1.1)
  * octokit (4.21.0)
  * parallel (1.21.0)
  * parser (3.0.2.0)
  * pathutil (0.16.2)
  * pry (0.14.1)
  * public_suffix (4.0.6)
  * racc (1.6.0)
  * rack (2.2.3)
  * rainbow (3.0.0)
  * rb-fsevent (0.11.0)
  * rb-inotify (0.10.1)
  * rexml (3.2.5)
  * rouge (3.26.0)
  * rspec (3.10.0)
  * rspec-core (3.10.1)
  * rspec-expectations (3.10.1)
  * rspec-mocks (3.10.2)
  * rspec-support (3.10.3)
  * rubocop (0.82.0)
  * rubocop-github (0.16.0)
  * rubocop-performance (1.7.1)
  * rubocop-rails (2.6.0)
  * ruby-enum (0.9.0)
  * ruby-progressbar (1.11.0)
  * ruby2_keywords (0.0.5)
  * rubyzip (2.3.2)
  * safe_yaml (1.0.5)
  * sass (3.7.4)
  * sass-listen (4.0.0)
  * sawyer (0.8.2)
  * simpleidn (0.2.1)
  * terminal-table (1.8.0)
  * thread_safe (0.3.6)
  * typhoeus (1.4.0)
  * tzinfo (1.2.9)
  * unf (0.1.4)
  * unf_ext (0.0.8)
  * unicode-display_width (1.8.0)
  * webmock (3.14.0)
  * zeitwerk (2.5.1)
```