### PR TITLE
Bring back --future option

### DIFF
--- a/bin/github-pages
+++ b/bin/github-pages
@@ -64,6 +64,7 @@ Mercenary.program(:"github-pages") do |p|
     c.option 'verbose', '--verbose', 'Verbose logging'
     c.option 'source', '--source DIR', 'From where to collect the source files'
     c.option 'destination', '--destination DIR', 'To where the compiled files should be written'
+    c.option 'future', '--future', 'Publishes posts with a future date'
 
     c.action do |_, options|
       Jekyll::Commands::Build.process(options)


### PR DESCRIPTION
With the [move to Pages on Actions (for public repositories)](https://github.blog/changelog/2021-12-16-github-pages-using-github-actions-for-builds-and-deployments-for-public-repositories/) we started to build sites without passing the `--future` option [we used to set](https://github.com/github/pages-gem/pull/302).

This PR adds Jekyll's `--future` option to `github-pages build`.