### PR TITLE
Update automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 CNAME
 test-site/
 vendor/
+tmp/

--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ See [all releases](https://github.com/github/pages-gem/releases).
 
 To release a new version of this gem, run `script/release` from the `master` branch.
 
+This will create and tag the release.
+
+It will also create prs in the relevant repos and assign them to you. It is your responsibility to
+
+1. update the version of the gem in those repos
+2. deploy those services as needed
+
+The relevant repos are: 
+1. [github-pages](https://github.com/github/pages)
+2. [jekyll-build-pages](https://github.com/actions/jekyll-build-pages/blob/main/Gemfile)
+3. [pages.github.com](https://github.com/github/pages.github.com)
+
 ## License
 
 Distributed under the [MIT License](LICENSE).

--- a/gh_pages_commit_input.json
+++ b/gh_pages_commit_input.json
@@ -1,7 +1,0 @@
-{
-    "tree": "8e473762f00cab18744b90f7d32557410e549869",
-    "parents": [
-        "cd957f6dab7a16078dbcb08576d7b60214192f43"
-    ],
-    "message": "automated commit for pr creation"
-}

--- a/gh_pages_commit_input.json
+++ b/gh_pages_commit_input.json
@@ -1,0 +1,7 @@
+{
+    "tree": "8e473762f00cab18744b90f7d32557410e549869",
+    "parents": [
+        "cd957f6dab7a16078dbcb08576d7b60214192f43"
+    ],
+    "message": "automated commit for pr creation"
+}

--- a/script/release
+++ b/script/release
@@ -82,9 +82,9 @@ gh api repos/actions/jekyll-build-pages/git/refs/heads/pages-gem-release-$tag -F
 gh api repos/github/pages.github.com/git/refs/heads/pages-gem-release-$tag -F "sha"="$new_gh_pages_site_sha" -F "ref"="refs/heads/pages-gem-release-$tag" -F "force"="true"
 
 # create pull requests in downstream repos
-gh pr create --base "master" --reviewer "@me" --head "pages-gem-release-$tag" --title "Bump pages-gem version to $tag" --assignee "@me" --body "Bump pages-gem version to $tag. You must manually make those changes and commit to this branch" --repo "github/pages" 
-gh pr create --base "main" --reviewer "@me" --head "pages-gem-release-$tag" --title "Bump pages-gem version to $tag" --assignee "@me" --body "Bump pages-gem version to $tag. You must manually make those changes and commit to this branch" --repo "actions/jekyll-build-pages"
-gh pr create --base "master" --reviewer "@me"  --head "pages-gem-release-$tag" --title "Bump pages-gem version to $tag" --assignee "@me" --body "Bump pages-gem version to $tag. You must manually make those changes and commit to this branch" --repo "github/pages.github.com"
+gh pr create --base "master" --head "pages-gem-release-$tag" --title "Bump pages-gem version to $tag" --assignee "@me" --body "Bump pages-gem version to $tag. You must manually make those changes and commit to this branch" --repo "github/pages" 
+gh pr create --base "main"  --head "pages-gem-release-$tag" --title "Bump pages-gem version to $tag" --assignee "@me" --body "Bump pages-gem version to $tag. You must manually make those changes and commit to this branch" --repo "actions/jekyll-build-pages"
+gh pr create --base "master" --head "pages-gem-release-$tag" --title "Bump pages-gem version to $tag" --assignee "@me" --body "Bump pages-gem version to $tag. You must manually make those changes and commit to this branch" --repo "github/pages.github.com"
 
 # clean up the input file for the commit
 

--- a/script/release
+++ b/script/release
@@ -1,4 +1,9 @@
 #!/bin/sh
+
+# check that gh is installed and logged in 
+
+gh auth status -h github.com
+
 # Tag and push a release.
 
 set -e
@@ -44,6 +49,10 @@ git push origin master && git push origin "$tag"
 # create a new release on github
 gh release create "$tag" --notes "Automated release for $tag"
 
+
+# create a tmp folder
+mkdir -p tmp
+
 #for each dependent repo, create a new branch an a blank pr. 
 # first get the sha of main for each repo 
 
@@ -61,19 +70,19 @@ gh api repos/github/pages/git/refs -F "sha"="$gh_pages_site_sha" -F "ref"="refs/
 
 gh_pages_tree = gh api repos/github/pages/git/commits/$gh_pages_sha | jq '. | .tree.sha'
 jekyll_tree = gh api repos/github/actions/jekyll-build-pages/commits/$jekyll_sha | jq '. | .tree.sha'
-gh_pages_site_tree = gh api repos/github/papages.github.comges/git/commits/$gh_pages_site_sha | jq '. | .tree.sha'
+gh_pages_site_tree = gh api repos/github/pages.github.com/git/commits/$gh_pages_site_sha | jq '. | .tree.sha'
 
 # create the input file for the commit. We have to do this because the F flag doesn't support arrays
 
-echo "{\"tree\": \"$gh_pages_tree\", \"parents\": [\"$gh_pages_sha\"], \"message\": \"automated commit for pr creation\"}" > gh_pages_commit_input.json
-echo "{\"tree\": \"$jekyll_tree\", \"parents\": [\"$jekyll_sha\"], \"message\": \"automated commit for pr creation\"}" > jekyll_commit_input.json
-echo "{\"tree\": \"$gh_pages_site_tree\", \"parents\": [\"$gh_pages_site_sha\"], \"message\": \"automated commit for pr creation\"}" > gh_pages_site_commit_input.json
+echo "{\"tree\": \"$gh_pages_tree\", \"parents\": [\"$gh_pages_sha\"], \"message\": \"automated commit for pr creation\"}" > tmp/h_pages_commit_input.json
+echo "{\"tree\": \"$jekyll_tree\", \"parents\": [\"$jekyll_sha\"], \"message\": \"automated commit for pr creation\"}" > tmp/jekyll_commit_input.json
+echo "{\"tree\": \"$gh_pages_site_tree\", \"parents\": [\"$gh_pages_site_sha\"], \"message\": \"automated commit for pr creation\"}" > tmp/gh_pages_site_commit_input.json
 
 # create the commit
 
-new_gh_pages_sha = gh api repos/github/pages/git/commits --input gh_pages_commit_input.json | jq '. | .sha' 
-new_jekyll_sha = gh api repos/actions/jekyll-build-pages/git/commits --input jekyll_commit_input.json | jq '. | .sha' 
-new_gh_pages_site_sha = gh api repos/github/pages.github.com/git/commits --input gh_pages_site_commit_input.json | jq '. | .sha' 
+new_gh_pages_sha = gh api repos/github/pages/git/commits --input tmp/gh_pages_commit_input.json | jq '. | .sha' 
+new_jekyll_sha = gh api repos/actions/jekyll-build-pages/git/commits --input tmp/jekyll_commit_input.json | jq '. | .sha' 
+new_gh_pages_site_sha = gh api repos/github/pages.github.com/git/commits --input tmp/gh_pages_site_commit_input.json | jq '. | .sha' 
 
 # associate the commit with the branch
 
@@ -88,4 +97,4 @@ gh pr create --base "master" --head "pages-gem-release-$tag" --title "Bump pages
 
 # clean up the input file for the commit
 
-rm gh_pages_commit_input.json jekyll_commit_input.json gh_pages_site_commit_input.json
+rm tmp/*

--- a/script/release
+++ b/script/release
@@ -39,4 +39,53 @@ git fetch -t origin
 # Tag it and bag it.
 
 gem push github-pages-*.gem && git tag "$tag" &&
-  git push origin master && git push origin "$tag"
+git push origin master && git push origin "$tag"
+
+# create a new release on github
+gh release create "$tag" --notes "Automated release for $tag"
+
+#for each dependent repo, create a new branch an a blank pr. 
+# first get the sha of main for each repo 
+
+gh_pages_sha = gh api repos/github/pages/git/refs/heads/master | jq '. | .object.sha'
+jekyll_sha = gh api repos/actions/jekyll-build-pages/git/refs/heads/main | jq '. | .object.sha'
+gh_pages_site_sha = gh api repos/github/pages.github.com/git/refs/heads/master | jq '. | .object.sha'
+
+# then create the branches 
+
+gh api repos/github/pages/git/refs -F "sha"="$gh_pages_sha" -F "ref"="refs/heads/pages-gem-release-$tag"
+gh api repos/github/pages/git/refs -F "sha"="$jekyll_sha" -F "ref"="refs/heads/pages-gem-release-$tag"
+gh api repos/github/pages/git/refs -F "sha"="$gh_pages_site_sha" -F "ref"="refs/heads/pages-gem-release-$tag"
+
+#then we need the tree object so we can create a commit using the api
+
+gh_pages_tree = gh api repos/github/pages/git/commits/$gh_pages_sha | jq '. | .tree.sha'
+jekyll_tree = gh api repos/github/actions/jekyll-build-pages/commits/$jekyll_sha | jq '. | .tree.sha'
+gh_pages_site_tree = gh api repos/github/papages.github.comges/git/commits/$gh_pages_site_sha | jq '. | .tree.sha'
+
+# create the input file for the commit. We have to do this because the F flag doesn't support arrays
+
+echo "{\"tree\": \"$gh_pages_tree\", \"parents\": [\"$gh_pages_sha\"], \"message\": \"automated commit for pr creation\"}" > gh_pages_commit_input.json
+echo "{\"tree\": \"$jekyll_tree\", \"parents\": [\"$jekyll_sha\"], \"message\": \"automated commit for pr creation\"}" > jekyll_commit_input.json
+echo "{\"tree\": \"$gh_pages_site_tree\", \"parents\": [\"$gh_pages_site_sha\"], \"message\": \"automated commit for pr creation\"}" > gh_pages_site_commit_input.json
+
+# create the commit
+
+new_gh_pages_sha = gh api repos/github/pages/git/commits --input gh_pages_commit_input.json | jq '. | .sha' 
+new_jekyll_sha = gh api repos/actions/jekyll-build-pages/git/commits --input jekyll_commit_input.json | jq '. | .sha' 
+new_gh_pages_site_sha = gh api repos/github/pages.github.com/git/commits --input gh_pages_site_commit_input.json | jq '. | .sha' 
+
+# associate the commit with the branch
+
+gh api repos/github/pages/git/refs/heads/pages-gem-release-$tag -F "sha"="$new_gh_pages_sha" -F "ref"="refs/heads/pages-gem-release-$tag" -F "force"="true"
+gh api repos/actions/jekyll-build-pages/git/refs/heads/pages-gem-release-$tag -F "sha"="$new_jekyll_sha" -F "ref"="refs/heads/pages-gem-release-$tag" -F "force"="true"
+gh api repos/github/pages.github.com/git/refs/heads/pages-gem-release-$tag -F "sha"="$new_gh_pages_site_sha" -F "ref"="refs/heads/pages-gem-release-$tag" -F "force"="true"
+
+# create pull requests in downstream repos
+gh pr create --base "master" --reviewer "@me" --head "pages-gem-release-$tag" --title "Bump pages-gem version to $tag" --assignee "@me" --body "Bump pages-gem version to $tag. You must manually make those changes and commit to this branch" --repo "github/pages" 
+gh pr create --base "main" --reviewer "@me" --head "pages-gem-release-$tag" --title "Bump pages-gem version to $tag" --assignee "@me" --body "Bump pages-gem version to $tag. You must manually make those changes and commit to this branch" --repo "actions/jekyll-build-pages"
+gh pr create --base "master" --reviewer "@me"  --head "pages-gem-release-$tag" --title "Bump pages-gem version to $tag" --assignee "@me" --body "Bump pages-gem version to $tag. You must manually make those changes and commit to this branch" --repo "github/pages.github.com"
+
+# clean up the input file for the commit
+
+rm gh_pages_commit_input.json jekyll_commit_input.json gh_pages_site_commit_input.json

--- a/script/release
+++ b/script/release
@@ -58,42 +58,35 @@ mkdir -p tmp
 
 gh_pages_sha = gh api repos/github/pages/git/refs/heads/master | jq '. | .object.sha'
 jekyll_sha = gh api repos/actions/jekyll-build-pages/git/refs/heads/main | jq '. | .object.sha'
-gh_pages_site_sha = gh api repos/github/pages.github.com/git/refs/heads/master | jq '. | .object.sha'
 
 # then create the branches 
 
 gh api repos/github/pages/git/refs -F "sha"="$gh_pages_sha" -F "ref"="refs/heads/pages-gem-release-$tag"
 gh api repos/github/pages/git/refs -F "sha"="$jekyll_sha" -F "ref"="refs/heads/pages-gem-release-$tag"
-gh api repos/github/pages/git/refs -F "sha"="$gh_pages_site_sha" -F "ref"="refs/heads/pages-gem-release-$tag"
 
 #then we need the tree object so we can create a commit using the api
 
 gh_pages_tree = gh api repos/github/pages/git/commits/$gh_pages_sha | jq '. | .tree.sha'
 jekyll_tree = gh api repos/github/actions/jekyll-build-pages/commits/$jekyll_sha | jq '. | .tree.sha'
-gh_pages_site_tree = gh api repos/github/pages.github.com/git/commits/$gh_pages_site_sha | jq '. | .tree.sha'
 
 # create the input file for the commit. We have to do this because the F flag doesn't support arrays
 
 echo "{\"tree\": \"$gh_pages_tree\", \"parents\": [\"$gh_pages_sha\"], \"message\": \"automated commit for pr creation\"}" > tmp/h_pages_commit_input.json
 echo "{\"tree\": \"$jekyll_tree\", \"parents\": [\"$jekyll_sha\"], \"message\": \"automated commit for pr creation\"}" > tmp/jekyll_commit_input.json
-echo "{\"tree\": \"$gh_pages_site_tree\", \"parents\": [\"$gh_pages_site_sha\"], \"message\": \"automated commit for pr creation\"}" > tmp/gh_pages_site_commit_input.json
 
 # create the commit
 
 new_gh_pages_sha = gh api repos/github/pages/git/commits --input tmp/gh_pages_commit_input.json | jq '. | .sha' 
 new_jekyll_sha = gh api repos/actions/jekyll-build-pages/git/commits --input tmp/jekyll_commit_input.json | jq '. | .sha' 
-new_gh_pages_site_sha = gh api repos/github/pages.github.com/git/commits --input tmp/gh_pages_site_commit_input.json | jq '. | .sha' 
 
 # associate the commit with the branch
 
 gh api repos/github/pages/git/refs/heads/pages-gem-release-$tag -F "sha"="$new_gh_pages_sha" -F "ref"="refs/heads/pages-gem-release-$tag" -F "force"="true"
 gh api repos/actions/jekyll-build-pages/git/refs/heads/pages-gem-release-$tag -F "sha"="$new_jekyll_sha" -F "ref"="refs/heads/pages-gem-release-$tag" -F "force"="true"
-gh api repos/github/pages.github.com/git/refs/heads/pages-gem-release-$tag -F "sha"="$new_gh_pages_site_sha" -F "ref"="refs/heads/pages-gem-release-$tag" -F "force"="true"
 
 # create pull requests in downstream repos
 gh pr create --base "master" --head "pages-gem-release-$tag" --title "Bump pages-gem version to $tag" --assignee "@me" --body "Bump pages-gem version to $tag. You must manually make those changes and commit to this branch" --repo "github/pages" 
 gh pr create --base "main"  --head "pages-gem-release-$tag" --title "Bump pages-gem version to $tag" --assignee "@me" --body "Bump pages-gem version to $tag. You must manually make those changes and commit to this branch" --repo "actions/jekyll-build-pages"
-gh pr create --base "master" --head "pages-gem-release-$tag" --title "Bump pages-gem version to $tag" --assignee "@me" --body "Bump pages-gem version to $tag. You must manually make those changes and commit to this branch" --repo "github/pages.github.com"
 
 # clean up the input file for the commit
 


### PR DESCRIPTION
This change seeks to ensure we mantain gem version parity as per [this issue ](https://github.com/github/pages-gem/issues/810) and the [subsequent card ](https://github.com/github/pages-engineering/issues/988), we really need to ensure we update the gem version in at least three places. 

This is the first pass at automating that change, via adding an automated tag release via the gh cli and creating new prs in the relevant repos so we know what work needs to be done, which will fire whenever anyone runs the release script

As part of the cleanup task I'd like to 

1. Add automation to the relevant repos that detects the new pr after the script creates them, runs an action and makes the changes based on that 
2. Automatically commits that change to the pr and sends a message to the pr creator. This should reduce the burden to just having to run three deploys (two actually, based on point 3)
3. I'd also like to get pages.github.com to somehow listen to changes via a github action, rather than rebuilding itself every 6 hours as originally suggested. However if that's too finicky (and based on preliminary investigation it may well be), we should just get it auto-rebuilding. If we do that we can cut the part of the automation that concerns itself with that repo. 
4. Finally, the automation could use some hardening, the script as it exists has no retry logic and no real failure handling. 

This is ready for a first pass. I've manually tested this by running through the command flow starting with line 46 in the script/release file (with some manual interpolations), as part of the work I'm going to create a new release which will test things end to end and let me clean up the dependent repos, but i'm going to tackle #3 first. 

Feedback on the idea, the implementation, and the general direction of this work. Its possible that point #1 is too much work for how often we release new gems, and we should focus on 2 and 3. 