### PR TITLE
Pass the UNSAFE option to commonmark

### DIFF
--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -153,7 +153,7 @@ module GitHubPages
         config["markdown"] = "CommonMarkGhPages"
         config["commonmark"] = {
           "extensions" => %w(table strikethrough autolink tagfilter),
-          "options" => %w(footnotes),
+          "options" => %w(unsafe footnotes),
         }
       end
 

--- a/spec/github-pages/configuration_spec.rb
+++ b/spec/github-pages/configuration_spec.rb
@@ -83,7 +83,7 @@ describe(GitHubPages::Configuration) do
           expect(effective_config["markdown"]).to eql("CommonMarkGhPages")
           expect(effective_config["commonmark"]).to eql(
             "extensions" => %w(table strikethrough autolink tagfilter),
-            "options" => %w(footnotes)
+            "options" => %w(unsafe footnotes)
           )
         end
       end


### PR DESCRIPTION
This is an omission and is needed for Markdown highlighting using the GFM renderer.

https://github.com/github/jekyll-commonmark-ghpages/pull/21/files

Add the `unsafe` option so HTML rendering of Markdown is supported.