### PR TITLE
(docker): add glibc compat to Alpine image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,7 +1,8 @@
 FROM ruby:2.7.3-alpine
 
 RUN apk update && apk add --no-cache \
-  git
+  git \
+  gcompat
 
 COPY . /src/gh/pages-gem
 


### PR DESCRIPTION
### the reason

the nokogiri gem depends on `glibc`

> Musl-based systems like Alpine may
> not have a glibc-compatible library
> installed, leading to problems running
> the precompiled native gems.

ref: <https://nokogiri.org/tutorials/installing_nokogiri.html#linux-musl-error-loading-shared-library>

extensive details at #839 

### what is affected
1. one more package and its two dependencies are installed via system package manager
2. image size increases by 1MB
***
resolves #839 