### PR TITLE
[Security] Require nokogiri 1.13.6 or greater

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency("mercenary", "~> 0.3")
-  s.add_dependency("nokogiri", ">= 1.13.4", "< 2.0")
+  s.add_dependency("nokogiri", ">= 1.13.6", "< 2.0")
   s.add_dependency("terminal-table", "~> 1.4")
   s.add_development_dependency("jekyll_test_plugin_malicious", "~> 0.2")
   s.add_development_dependency("pry", "~> 0.10")


### PR DESCRIPTION
Fixes https://github.com/github/pages-gem/issues/841 (Upgrade nokogiri to version 1.13.6 or later [CVE-2022-29181])