### PR TITLE
Remove unused variable `CONFIGS_WITH_METHODS`

### DIFF
--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -62,13 +62,6 @@ module GitHubPages
       },
     }.freeze
 
-    # These configuration settings have corresponding instance variables on
-    # Jekyll::Site and need to be set properly when the config is updated.
-    CONFIGS_WITH_METHODS = %w(
-      safe lsi highlighter baseurl exclude include future unpublished
-      show_drafts limit_posts keep_files
-    ).freeze
-
     class << self
       def processed?(site)
         site.instance_variable_get(:@_github_pages_processed) == true


### PR DESCRIPTION
It looks like the references to the `CONFIGS_WITH_METHODS` variable were removed way back in `v158` but the definition is still present.

[Compare `v157`..`v158`](https://github.com/github/pages-gem/compare/v157..v158#diff-577aa6cfe09866693f9c87c4aff83d66df2a9ebe56deda981315348142119af3)