### PR TITLE
Whitelist the `jekyll-data` plugin

### DIFF
--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -39,6 +39,7 @@ module GitHubPages
       jekyll-include-cache
       jekyll-octicons
       jekyll-remote-theme
+      jekyll-data
     ).freeze
 
     # Plugins only allowed locally


### PR DESCRIPTION
fixes: https://github.com/github/pages-gem/issues/610

Whitelist [jekyll-data](https://github.com/ashmaroli/jekyll-data).

This allows people using GitHub pages to use themes that provide defaults in their `_config.yml` and have data under `_data/`.

For example, this would allow organisations that compose multiple GitHub repositories into a single site to use a common theme, that sets defaults in the theme's `_config.yml` and has shared `_data` structures, like navigation menus, 

