### PR TITLE
build: update liquid to 4.0.4

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -16,7 +16,7 @@ module GitHubPages
       "jekyll-commonmark-ghpages" => "0.2.0",
 
       # Misc
-      "liquid" => "4.0.3",
+      "liquid" => "4.0.4",
       "rouge" => "3.26.0",
       "github-pages-health-check" => "1.17.9",
 


### PR DESCRIPTION
Ruby 3.2 removed the "tainted" interface, which liquid <=4.0.3
still uses. Liquid 4.0.4 removes references to this interface so that
it works with Ruby 3.2.

Closes https://github.com/github/pages-gem/issues/859.