### PR TITLE
Fix compatibility with new ruby versions

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -16,7 +16,7 @@ module GitHubPages
       "jekyll-commonmark-ghpages" => "0.2.0",
 
       # Misc
-      "liquid" => "4.0.3",
+      "liquid" => "4.0.4",
       "rouge" => "3.26.0",
       "github-pages-health-check" => "1.17.9",
 


### PR DESCRIPTION
Update liquid because of https://github.com/jekyll/jekyll/issues/9233.