### PR TITLE
Bump jekyll to v3.9.3 and pages-gem to v228

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -7,7 +7,7 @@ module GitHubPages
   class Dependencies
     VERSIONS = {
       # Jekyll
-      "jekyll" => "3.9.2",
+      "jekyll" => "3.9.3",
       "jekyll-sass-converter" => "1.5.2",
 
       # Converters

--- a/lib/github-pages/version.rb
+++ b/lib/github-pages/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GitHubPages
-  VERSION = 227
+  VERSION = 228
 end


### PR DESCRIPTION
Now that [`jekyll` `3.9.3` is out](https://github.com/jekyll/jekyll/pull/9282), thanks to @parkr, a new `pages-gem` release needs to be made that depends on `= 3.9.3` instead of `= 3.9.2`.

Closes #866