### PR TITLE
Fixes `$github-pages health-check` NoMethodError

### DIFF
--- a/bin/github-pages
+++ b/bin/github-pages
@@ -43,7 +43,7 @@ Mercenary.program(:"github-pages") do |p|
     c.action do |args, options|
       require 'github-pages-health-check'
       cname_path = File.expand_path "CNAME", Dir.pwd
-      raise "No CNAME file found in current directory" unless File.exists?(cname_path)
+      raise "No CNAME file found in current directory" unless File.exist?(cname_path)
       cname = File.open(cname_path).read.strip
       check = GitHubPages::HealthCheck.check(cname)
       puts "Checking domain #{cname}..."


### PR DESCRIPTION
Running `$github-pages health-check` will cause a `NoMethodError` exception because `File.exists?` is not defined.

This patch updates it to use `File.exist?` which is what I think was intended.