### PR TITLE
Mention Ruby version support and WEBrick dependency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ The version of Ruby with which Jekyll is executed. Although Jekyll itself may be
 
 This includes Markdown processors, and any other Jekyll dependency for which version incongruency may produce unexpected results. Traditionally, Maruku, Kramdown, RedCloth, liquid, rdiscount, and redcarpet have been strictly maintained due to known breaking changes.
 
+Note, the GitHub Pages gem does not yet support Ruby 3.x. If you're running Ruby 3.x, be sure to install [the WEBrick gem](https://rubygems.org/gems/webrick) or add it to your Gemfile.
+
 ## Changelog
 
 See [all releases](https://github.com/github/pages-gem/releases).


### PR DESCRIPTION
per https://github.com/github/pages-gem/issues/752#issuecomment-764758292:

> Hi! In general, we recommend (and support) running the github-pages gem with the Ruby version we're running in production (2.7.x). We don't yet support Ruby 3.0.0. Ruby 2.7.x still has webrick so I'd recommend using that until we've upgraded for your GitHub Pages needs!