### PR TITLE
Bump terminal-table to 3.0.2

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("mercenary", "~> 0.3")
   s.add_dependency("nokogiri", ">= 1.13.6", "< 2.0")
-  s.add_dependency("terminal-table", "~> 1.4")
+  s.add_dependency("terminal-table", "~> 3.0")
   s.add_development_dependency("jekyll_test_plugin_malicious", "~> 0.2")
   s.add_development_dependency("pry", "~> 0.10")
   s.add_development_dependency("rspec", "~> 3.3")


### PR DESCRIPTION
Prevents a dependency conflict with `steep`.