### PR TITLE
Add Ruby 3.0, 3.1, 3.2, and 3.3 to CI, and retire 2.6

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,8 +7,10 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.6
           - 2.7
+          - 3.0
+          - 3.1
+          - 3.2
     steps:
     - uses: actions/checkout@v3
     - name: script/cibuild-docker

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,6 +11,7 @@ jobs:
           - 3.0
           - 3.1
           - 3.2
+          - 3.3
     steps:
     - uses: actions/checkout@v3
     - name: script/cibuild-docker


### PR DESCRIPTION
Ruby is moving forward, and Pages must follow or risk security issues and poor developer experience.