### PR TITLE
Bump jekyll to v3.9.4

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -7,7 +7,7 @@ module GitHubPages
   class Dependencies
     VERSIONS = {
       # Jekyll
-      "jekyll" => "3.9.3",
+      "jekyll" => "3.9.4",
       "jekyll-sass-converter" => "1.5.2",
 
       # Converters


### PR DESCRIPTION
Adds Ruby 3.3 support. (https://github.com/jekyll/jekyll/releases/tag/v3.9.4)

@yoannchaudet, if you'd like to bring support up to Ruby 3.3, this tiny v3.9.4 release has been made available for you!