### PR TITLE
Bring back proper support for Ruby 3.x

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,8 +7,10 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.0'
-          - '3.3'
+          - 3.0
+          - 3.1
+          - 3.2
+          - 3.3
     steps:
     - uses: actions/checkout@v4
     - name: script/cibuild-docker

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,10 +7,10 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 3.0
-          - 3.1
-          - 3.2
-          - 3.3
+          - '3.0'
+          - '3.1'
+          - '3.2'
+          - '3.3'
     steps:
     - uses: actions/checkout@v4
     - name: script/cibuild-docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,6 @@ RUN apt-get update \
     make \
     nodejs
 
-# final version for rubygems-update to supoprt ruby 2.7, consider removing this after upgraded to ruby 3.0
-RUN gem update --system
-
 COPY .git /src/gh/pages-gem/.git
 COPY Gemfile* /src/gh/pages-gem/
 COPY github-pages.gemspec /src/gh/pages-gem

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -63,7 +63,7 @@ module GitHubPages
       require "nokogiri"
 
       {
-        "ruby" => "3.3",
+        "ruby" => RUBY_VERSION,
 
         # Gem versions we're curious about
         "github-pages" => VERSION.to_s,


### PR DESCRIPTION
Address https://github.com/github/pages-gem/pull/895 on top of the latest changes in this repo.

Adding back all versions of Ruby still supported https://endoflife.date/ruby.