### PR TITLE
Bump Jekyll to 3.9.5

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -7,7 +7,7 @@ module GitHubPages
   class Dependencies
     VERSIONS = {
       # Jekyll
-      "jekyll" => "3.9.4",
+      "jekyll" => "3.9.5",
       "jekyll-sass-converter" => "1.5.2",
 
       # Converters

--- a/lib/github-pages/version.rb
+++ b/lib/github-pages/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GitHubPages
-  VERSION = 229
+  VERSION = 230
 end


### PR DESCRIPTION
This includes https://github.com/jekyll/jekyll/pull/9550.