### PR TITLE
Revert jekyll-relative-links to 0.6.1 and add a test

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -36,7 +36,7 @@ module GitHubPages
       # Plugins to match GitHub.com Markdown
       "jemoji" => "0.13.0",
       "jekyll-mentions" => "1.6.0",
-      "jekyll-relative-links" => "0.7.0",
+      "jekyll-relative-links" => "0.6.1",
       "jekyll-optional-front-matter" => "0.3.2",
       "jekyll-readme-index" => "0.3.0",
       "jekyll-default-layout" => "0.1.5",

--- a/lib/github-pages/version.rb
+++ b/lib/github-pages/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GitHubPages
-  VERSION = 230
+  VERSION = 231
 end

--- a/spec/fixtures/jekyll-relative-links.md
+++ b/spec/fixtures/jekyll-relative-links.md
@@ -1,5 +1,7 @@
 ---
+excerpt: Just a relative link
 ---
 
-
 [Jekyll](jekyll.md)
+
+{{ page.excerpt }}

--- a/spec/github-pages/integration_spec.rb
+++ b/spec/github-pages/integration_spec.rb
@@ -224,6 +224,7 @@ RSpec.describe "Pages Gem Integration spec" do
     context "jekyll-relative-links" do
       it "converts relative links" do
         expect(contents).to match('<a href="/jekyll.html">Jekyll</a>')
+        expect(contents).to match('<p>Just a relative link</p>') # excerpt
       end
     end
 

--- a/spec/github-pages/integration_spec.rb
+++ b/spec/github-pages/integration_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe "Pages Gem Integration spec" do
     context "jekyll-relative-links" do
       it "converts relative links" do
         expect(contents).to match('<a href="/jekyll.html">Jekyll</a>')
-        expect(contents).to match('<p>Just a relative link</p>') # excerpt
+        expect(contents).to match("<p>Just a relative link</p>") # excerpt
       end
     end
 


### PR DESCRIPTION
Prep release 231.

It rolls back jekyll-relative-links to 0.6.1 and while at it, add a test for front matter based excerpt which stopped working for some reasons.

Related https://github.com/jekyll/jekyll/issues/9544