### PR TITLE
Fix obscured gemfile issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
+ENV BUNDLE_GEMFILE=/src/gh/pages-gem/Gemfile
+
 WORKDIR /src/site
 
 CMD ["jekyll", "serve", "-H", "0.0.0.0", "-P", "4000"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -17,6 +17,8 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
+ENV BUNDLE_GEMFILE=/src/gh/pages-gem/Gemfile
+
 WORKDIR /src/site
 
 CMD ["jekyll", "serve", "-H", "0.0.0.0", "-P", "4000"]


### PR DESCRIPTION
(edited to include just one change per [@parkr’s suggestion](https://github.com/github/pages-gem/pull/912#issuecomment-2004587675)—see also stacked PR #914)

Fixes #891. `jekyll` was unable to find the gems which Bundler had installed as part of the `Dockerfile` because it was finding a `Gemfile` in the currently working directory (`/src/site`), which belongs to the site being built. I resolved this by setting an environment variable to tell Bundler where to find the correct `Gemfile`.

I’m not a Ruby developer, so I might not have done this conventionally. However it seems to work, and it was the minimum change I could make to resolve those issues.