### PR TITLE
Add webrick as Ruby 3 doesn’t include it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
+ENV BUNDLE_GEMFILE=/src/gh/pages-gem/Gemfile
+
 WORKDIR /src/site
 
 CMD ["jekyll", "serve", "-H", "0.0.0.0", "-P", "4000"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -17,6 +17,8 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
+ENV BUNDLE_GEMFILE=/src/gh/pages-gem/Gemfile
+
 WORKDIR /src/site
 
 CMD ["jekyll", "serve", "-H", "0.0.0.0", "-P", "4000"]

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -9,6 +9,7 @@ module GitHubPages
       # Jekyll
       "jekyll" => "3.9.5",
       "jekyll-sass-converter" => "1.5.2",
+      "webrick" => "1.8.1",
 
       # Converters
       "kramdown" => "2.4.0",


### PR DESCRIPTION
Fixes #752. `webrick` wasn’t available it’s [not bundled as of Ruby v3.0.0](https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/). I’ve resolved this by adding it to the dependencies class.