### PR TITLE
Upgrade to Jekyll 3.10.0

### DIFF
--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -7,7 +7,7 @@ module GitHubPages
   class Dependencies
     VERSIONS = {
       # Jekyll
-      "jekyll" => "3.9.5",
+      "jekyll" => "3.10.0",
       "jekyll-sass-converter" => "1.5.2",
 
       # Converters


### PR DESCRIPTION
No functionality is changed. Since Ruby 3.0 dropped webrick and Ruby 3.4 is going to drop csv, this adds them back as dependencies.

https://jekyllrb.com/news/2024/06/23/jekyll-3-10-0-released/

Fixes #899.
Fixes https://github.com/github/pages-gem/issues/887.
Fixes https://github.com/github/pages-gem/issues/864.
Fixes https://github.com/github/pages-gem/issues/752.

/cc @yoannchaudet 