### PR TITLE
Bump of webrick version to 1.8.2

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency("mercenary", "~> 0.3")
   s.add_dependency("nokogiri", ">= 1.16.2", "< 2.0")
   s.add_dependency("terminal-table", "~> 1.4")
-  s.add_dependency("webrick", "~> 1.8")
+  s.add_dependency("webrick", "~> 1.8.2")
   s.add_development_dependency("jekyll_test_plugin_malicious", "~> 0.2")
   s.add_development_dependency("pry", "~> 0.10")
   s.add_development_dependency("rspec", "~> 3.3")


### PR DESCRIPTION
Versions prior to 1.8.2 has a security issue with HTTP Request Smuggling

Snyk: https://security.snyk.io/vuln/SNYK-RUBY-WEBRICK-8068535
CVE: https://www.cve.org/CVERecord?id=CVE-2024-47220

The CWE explanation:
- https://cwe.mitre.org/data/definitions/444.html

This PR bumps the requirement to version 1.8.2 from 1.8